### PR TITLE
Expose whether or not the SignalR connection has completely started up.

### DIFF
--- a/src/main/java/com/oneidentity/safeguard/safeguardjava/event/ISafeguardEventListener.java
+++ b/src/main/java/com/oneidentity/safeguard/safeguardjava/event/ISafeguardEventListener.java
@@ -39,6 +39,11 @@ public interface ISafeguardEventListener
     void stop() throws ObjectDisposedException, SafeguardForJavaException;
 
     /**
+     * Indicates whether the SignalR connection has completed start up.
+     */
+    boolean isStarted();
+
+    /**
      *  Disposes of the connection.
      *  
      */  

--- a/src/main/java/com/oneidentity/safeguard/safeguardjava/event/PersistentSafeguardEventListenerBase.java
+++ b/src/main/java/com/oneidentity/safeguard/safeguardjava/event/PersistentSafeguardEventListenerBase.java
@@ -107,6 +107,11 @@ public abstract class PersistentSafeguardEventListenerBase implements ISafeguard
     }
 
     @Override
+    public boolean isStarted() {
+        return this.eventListener == null ? false : this.eventListener.isStarted();
+    }
+    
+    @Override
     public void dispose() {
         if (this.eventListener != null) {
             this.eventListener.dispose();


### PR DESCRIPTION
This lets the caller deal with how to handle the connection if it never starts or to wait longer for start up.