### PR TITLE
Update to the latest 6.7 changes.  

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,9 @@ String jsonBody = new StringBuffer ("{")
 String json = connection.invokeMethod(Service.Core, Method.Post, "Assets", jsonBody, null, null);
 System.out.println(json);
 ```
+
 #### Create a New User and Set the Password
+
 ```Java
 // Assume connection is already made
 String jsonBody = new StringBuffer ("{")
@@ -144,6 +146,37 @@ String userJson = connection.invokeMethod(Service.Core, Method.Post, "Users", js
 UserObj userObj = new Gson().fromJson(userJson, UserObj.class);
 connection.invokeMethod(Service.Core, Method.Put, String.format("Users/%s/Password", userObj.Id), "{\"MyNewUser123\"}");
 ```
+
+#### Using an SSL Certificate Validation Callback
+
+```Java
+ISafeguardConnection connection = Safeguard.connect("safeguard.sample.corp", "local", "myuser", "secret".toCharArray(), new CertificateValidator(), null);
+
+String userJson = connection.invokeMethod(Service.Core, Method.Get, "Users", null, null, null);
+```
+
+```Java
+package com.mycompany.mypackage;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSession;
+
+public class CertificateValidator implements HostnameVerifier {
+
+    @Override
+    public boolean verify(final String s, final SSLSession sslSession) {
+        // Do your validation here
+        return <true | false>; // Return the result of the validation.
+    }
+
+    @Override
+    public final String toString() {
+        return "CertificateValidator";
+    }
+}
+
+```
+
 ### Building SafeguardJava
 
 Building SafeguardJava requires Java JDK 8 or greater and Maven 3.0.5 or greater.  The following dependency should be added to your POM file:
@@ -153,5 +186,4 @@ Building SafeguardJava requires Java JDK 8 or greater and Maven 3.0.5 or greater
             <artifactId>safeguardjava</artifactId>
             <version>2.10.0</version>
         </dependency>
-
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     
     <groupId>com.oneidentity.safeguard</groupId>
     <artifactId>safeguardjava</artifactId>
-    <version>6.1.0-SNAPSHOT</version>
+    <version>6.7.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     
     <name>safeguardjava</name>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.3</version>
+            <version>2.9.10.5</version>
             <type>jar</type>
         </dependency>           
         <dependency>
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.java-websocket</groupId>
             <artifactId>Java-WebSocket</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.1</version>
         </dependency>
     </dependencies>
     

--- a/src/main/java/com/oneidentity/safeguard/safeguardjava/Safeguard.java
+++ b/src/main/java/com/oneidentity/safeguard/safeguardjava/Safeguard.java
@@ -13,6 +13,7 @@ import com.oneidentity.safeguard.safeguardjava.exceptions.SafeguardForJavaExcept
 import com.oneidentity.safeguard.safeguardjava.event.ISafeguardEventHandler;
 import com.oneidentity.safeguard.safeguardjava.exceptions.ArgumentException;
 import java.util.List;
+import javax.net.ssl.HostnameVerifier;
 
 /**
  * This static class provides static methods for connecting to Safeguard API.
@@ -55,9 +56,32 @@ public final class Safeguard {
 
         // Don't try to refresh access token on the access token connect method because it cannot be refreshed
         // So, don't use GetConnection() function above
-        return new SafeguardConnection(new AccessTokenAuthenticator(networkAddress, accessToken, version, sslIgnore));
+        return new SafeguardConnection(new AccessTokenAuthenticator(networkAddress, accessToken, version, sslIgnore, null));
     }
 
+    /**
+     *  Connect to Safeguard API using an API access token.
+     *
+     *  @param networkAddress Network address of Safeguard appliance.
+     *  @param accessToken Existing API access token.
+     *  @param apiVersion Target API version to use.
+     *  @param validationCallback Callback function to be executed during SSL certificate validation.
+     * 
+     *  @return Reusable Safeguard API connection.
+     *  @throws ArgumentException Invalid argument.
+     */
+    public static ISafeguardConnection connect(String networkAddress, char[] accessToken,
+            HostnameVerifier validationCallback, Integer apiVersion) throws ArgumentException {
+        int version = DEFAULTAPIVERSION;
+        if (apiVersion != null) {
+            version = apiVersion;
+        }
+
+        // Don't try to refresh access token on the access token connect method because it cannot be refreshed
+        // So, don't use GetConnection() function above
+        return new SafeguardConnection(new AccessTokenAuthenticator(networkAddress, accessToken, version, false, validationCallback));
+    }
+    
     /**
      *  Connect to Safeguard API using a user name and password.
      *
@@ -73,7 +97,8 @@ public final class Safeguard {
      *  @throws SafeguardForJavaException General Safeguard for Java exception.
      */
     public static ISafeguardConnection connect(String networkAddress, String provider, String username,
-            char[] password, Integer apiVersion, Boolean ignoreSsl) throws ObjectDisposedException, ArgumentException, SafeguardForJavaException {
+            char[] password, Integer apiVersion, Boolean ignoreSsl) 
+            throws ObjectDisposedException, ArgumentException, SafeguardForJavaException {
         int version = DEFAULTAPIVERSION;
         if (apiVersion != null) {
             version = apiVersion;
@@ -85,7 +110,33 @@ public final class Safeguard {
         }
 
         return getConnection(new PasswordAuthenticator(networkAddress, provider, username, password, version,
-                sslIgnore));
+                sslIgnore, null));
+    }
+
+    /**
+     *  Connect to Safeguard API using a user name and password.
+     *
+     *  @param networkAddress Network address of Safeguard appliance.
+     *  @param provider Safeguard authentication provider name (e.g. local).
+     *  @param username User name to use for authentication.
+     *  @param password User password to use for authentication.
+     *  @param apiVersion Target API version to use.
+     *  @param validationCallback Callback function to be executed during SSL certificate validation.
+     *  @return Reusable Safeguard API connection.
+     *  @throws ObjectDisposedException Object has already been disposed.
+     *  @throws ArgumentException Invalid argument.
+     *  @throws SafeguardForJavaException General Safeguard for Java exception.
+     */
+    public static ISafeguardConnection connect(String networkAddress, String provider, String username,
+            char[] password, HostnameVerifier validationCallback, Integer apiVersion) 
+            throws ObjectDisposedException, ArgumentException, SafeguardForJavaException {
+        int version = DEFAULTAPIVERSION;
+        if (apiVersion != null) {
+            version = apiVersion;
+        }
+
+        return getConnection(new PasswordAuthenticator(networkAddress, provider, username, password, version,
+                false, validationCallback));
     }
 
     /**
@@ -103,8 +154,10 @@ public final class Safeguard {
      *  @throws ObjectDisposedException Object has already been disposed.
      *  @throws SafeguardForJavaException General Safeguard for Java exception.
      */
-    public static ISafeguardConnection connect(String networkAddress, String keystorePath, char[] keystorePassword, String certificateAlias,
-            Integer apiVersion, Boolean ignoreSsl) throws ObjectDisposedException, SafeguardForJavaException {
+    public static ISafeguardConnection connect(String networkAddress, String keystorePath, 
+            char[] keystorePassword, String certificateAlias,
+            Integer apiVersion, Boolean ignoreSsl) 
+            throws ObjectDisposedException, SafeguardForJavaException {
         int version = DEFAULTAPIVERSION;
         if (apiVersion != null) {
             version = apiVersion;
@@ -115,7 +168,36 @@ public final class Safeguard {
             sslIgnore = ignoreSsl;
         }
 
-        return getConnection(new CertificateAuthenticator(networkAddress, keystorePath, keystorePassword, certificateAlias, version, sslIgnore));
+        return getConnection(new CertificateAuthenticator(networkAddress, keystorePath, 
+                keystorePassword, certificateAlias, version, sslIgnore, null));
+    }
+
+    /**
+     *  Connect to Safeguard API using a certificate from the keystore. The
+     *  appropriate keystore must have been loaded in the java process.
+     *
+     *  @param networkAddress Network address of Safeguard appliance.
+     *  @param keystorePath Path to the keystore containing the client certificate.
+     *  @param keystorePassword Keystore password.
+     *  @param certificateAlias Alias identifying a client certificate in the keystore.
+     *  @param apiVersion Target API version to use.
+     *  @param validationCallback Callback function to be executed during SSL certificate validation.
+     * 
+     *  @return Reusable Safeguard API connection.
+     *  @throws ObjectDisposedException Object has already been disposed.
+     *  @throws SafeguardForJavaException General Safeguard for Java exception.
+     */
+    public static ISafeguardConnection connect(String networkAddress, String keystorePath, 
+            char[] keystorePassword, String certificateAlias,
+            HostnameVerifier validationCallback, Integer apiVersion) 
+            throws ObjectDisposedException, SafeguardForJavaException {
+        int version = DEFAULTAPIVERSION;
+        if (apiVersion != null) {
+            version = apiVersion;
+        }
+
+        return getConnection(new CertificateAuthenticator(networkAddress, keystorePath, 
+                keystorePassword, certificateAlias, version, false, validationCallback));
     }
 
     /**
@@ -133,7 +215,8 @@ public final class Safeguard {
      *  @throws SafeguardForJavaException General Safeguard for Java exception.
      */
     public static ISafeguardConnection connect(String networkAddress, String certificatePath,
-            char[] certificatePassword, Integer apiVersion, Boolean ignoreSsl) throws ObjectDisposedException, SafeguardForJavaException {
+            char[] certificatePassword, Integer apiVersion, Boolean ignoreSsl) 
+            throws ObjectDisposedException, SafeguardForJavaException {
         int version = DEFAULTAPIVERSION;
         if (apiVersion != null) {
             version = apiVersion;
@@ -145,7 +228,33 @@ public final class Safeguard {
         }
 
         return getConnection(new CertificateAuthenticator(networkAddress, certificatePath, certificatePassword,
-                version, sslIgnore));
+                version, sslIgnore, null));
+    }
+
+    /**
+     *  Connect to Safeguard API using a certificate stored in a file.
+     *
+     *  @param networkAddress Network address of Safeguard appliance.
+     *  @param certificatePath Path to PFX (or PKCS12) certificate file also
+     *  containing private key.
+     *  @param certificatePassword Password to decrypt the certificate file.
+     *  @param apiVersion Target API version to use.
+     *  @param validationCallback Callback function to be executed during SSL certificate validation.
+     * 
+     *  @return Reusable Safeguard API connection.
+     *  @throws ObjectDisposedException Object has already been disposed.
+     *  @throws SafeguardForJavaException General Safeguard for Java exception.
+     */
+    public static ISafeguardConnection connect(String networkAddress, String certificatePath,
+            char[] certificatePassword, HostnameVerifier validationCallback, Integer apiVersion) 
+            throws ObjectDisposedException, SafeguardForJavaException {
+        int version = DEFAULTAPIVERSION;
+        if (apiVersion != null) {
+            version = apiVersion;
+        }
+
+        return getConnection(new CertificateAuthenticator(networkAddress, certificatePath, certificatePassword,
+                version, false, validationCallback));
     }
 
     /**
@@ -176,7 +285,33 @@ public final class Safeguard {
         }
 
         return getConnection(new CertificateAuthenticator(networkAddress, certificateData, certificatePassword, certificateAlias,
-                version, sslIgnore));
+                version, sslIgnore, null));
+    }
+    
+    /**
+     *  Connect to Safeguard API using a certificate stored in memory.
+     *
+     *  @param networkAddress Network address of Safeguard appliance.
+     *  @param certificateData Bytes containing a PFX (or PKCS12) formatted certificate and private key.
+     *  @param certificatePassword Password to decrypt the certificate data.
+     *  @param certificateAlias Alias identifying a client certificate in the keystore.
+     *  @param apiVersion Target API version to use.
+     *  @param validationCallback Callback function to be executed during SSL certificate validation.
+     * 
+     *  @return Reusable Safeguard API connection.
+     *  @throws ObjectDisposedException Object has already been disposed.
+     *  @throws SafeguardForJavaException General Safeguard for Java exception.
+     */
+    public static ISafeguardConnection connect(String networkAddress, byte[] certificateData,
+            char[] certificatePassword, String certificateAlias, HostnameVerifier validationCallback, Integer apiVersion) 
+            throws ObjectDisposedException, SafeguardForJavaException {
+        int version = DEFAULTAPIVERSION;
+        if (apiVersion != null) {
+            version = apiVersion;
+        }
+
+        return getConnection(new CertificateAuthenticator(networkAddress, certificateData, certificatePassword, certificateAlias,
+                version, false, validationCallback));
     }
     
     /**
@@ -187,8 +322,10 @@ public final class Safeguard {
      *  @param ignoreSsl If set to <code>true</code> ignore ssl.
      * 
      *  @return The connect.
+     *  @throws com.oneidentity.safeguard.safeguardjava.exceptions.SafeguardForJavaException
      */
-    public static ISafeguardConnection connect(String networkAddress, Integer apiVersion, Boolean ignoreSsl) {
+    public static ISafeguardConnection connect(String networkAddress, Integer apiVersion, Boolean ignoreSsl) 
+            throws SafeguardForJavaException {
         int version = DEFAULTAPIVERSION;
         if (apiVersion != null) {
             version = apiVersion;
@@ -201,9 +338,31 @@ public final class Safeguard {
 
         // Don't try to refresh access token on the anonymous connect method because it cannot be refreshed
         // So, don't use GetConnection() function above
-        return new SafeguardConnection(new AnonymousAuthenticator(networkAddress, version, sslIgnore));
+        return new SafeguardConnection(new AnonymousAuthenticator(networkAddress, version, sslIgnore, null));
     }
 
+    /**
+     *  Connect to Safeguard API anonymously.
+     *
+     *  @param networkAddress Network address.
+     *  @param apiVersion API version.
+     *  @param validationCallback Callback function to be executed during SSL certificate validation.
+     * 
+     *  @return The connect.
+     *  @throws com.oneidentity.safeguard.safeguardjava.exceptions.SafeguardForJavaException
+     */
+    public static ISafeguardConnection connect(String networkAddress, HostnameVerifier validationCallback, Integer apiVersion) 
+            throws SafeguardForJavaException {
+        int version = DEFAULTAPIVERSION;
+        if (apiVersion != null) {
+            version = apiVersion;
+        }
+
+        // Don't try to refresh access token on the anonymous connect method because it cannot be refreshed
+        // So, don't use GetConnection() function above
+        return new SafeguardConnection(new AnonymousAuthenticator(networkAddress, version, false, validationCallback));
+    }
+    
     /**
      *  This static class provides access to Safeguard Event functionality with
      *  persistent event listeners. Persistent event listeners can handle longer
@@ -245,7 +404,37 @@ public final class Safeguard {
             }
 
             return new PersistentSafeguardEventListener(getConnection(
-                    new PasswordAuthenticator(networkAddress, provider, username, password, version, ignoreSsl)));
+                    new PasswordAuthenticator(networkAddress, provider, username, password, version, ignoreSsl, null)));
+        }
+
+        /**
+         *  Get a persistent event listener using a username and password
+         *  credential for authentication.
+         *
+         *  @param networkAddress Network address of Safeguard appliance.
+         *  @param provider Safeguard authentication provider name (e.g. local).
+         *  @param username User name to use for authentication.
+         *  @param password User password to use for authentication.
+         *  @param apiVersion Target API version to use.
+         *  @param validationCallback Callback function to be executed during SSL certificate validation.
+         * 
+         *  @return New persistent Safeguard event listener.
+         *  @throws ObjectDisposedException Object has already been disposed.
+         *  @throws SafeguardForJavaException General Safeguard for Java
+         *  @throws ArgumentException Invalid argument.
+         *  exception.
+         */
+        public static ISafeguardEventListener getPersistentEventListener(String networkAddress, String provider,
+                String username, char[] password, HostnameVerifier validationCallback, Integer apiVersion)
+                throws ObjectDisposedException, SafeguardForJavaException, ArgumentException {
+            
+            int version = DEFAULTAPIVERSION;
+            if (apiVersion != null) {
+                version = apiVersion;
+            }
+
+            return new PersistentSafeguardEventListener(getConnection(
+                    new PasswordAuthenticator(networkAddress, provider, username, password, version, false, validationCallback)));
         }
 
         /**
@@ -278,7 +467,35 @@ public final class Safeguard {
             }
 
             return new PersistentSafeguardEventListener(getConnection(
-                    new CertificateAuthenticator(networkAddress, certificatePath, certificatePassword, version, ignoreSsl)));
+                    new CertificateAuthenticator(networkAddress, certificatePath, certificatePassword, version, ignoreSsl, null)));
+        }
+
+        /**
+         *  Get a persistent event listener using a client certificate stored in
+         *  a file.
+         *
+         *  @param networkAddress Network address of Safeguard appliance.
+         *  @param certificatePath Path to PFX (or PKCS12) certificate file also
+         *  containing private key.
+         *  @param certificatePassword Password to decrypt the certificate file.
+         *  @param apiVersion Target API version to use.
+         *  @param validationCallback Callback function to be executed during SSL certificate validation.
+         * 
+         *  @return New persistent Safeguard event listener.
+         *  @throws ObjectDisposedException Object has already been disposed.
+         *  @throws SafeguardForJavaException General Safeguard for Java
+         *  exception.
+         */
+        public static ISafeguardEventListener getPersistentEventListener(String networkAddress, String certificatePath,
+                char[] certificatePassword, HostnameVerifier validationCallback, Integer apiVersion)
+                throws ObjectDisposedException, SafeguardForJavaException {
+            int version = DEFAULTAPIVERSION;
+            if (apiVersion != null) {
+                version = apiVersion;
+            }
+
+            return new PersistentSafeguardEventListener(getConnection(
+                    new CertificateAuthenticator(networkAddress, certificatePath, certificatePassword, version, false, validationCallback)));
         }
 
         /**
@@ -310,7 +527,34 @@ public final class Safeguard {
             }
 
             return new PersistentSafeguardEventListener(getConnection(
-                    new CertificateAuthenticator(networkAddress, certificateData, certificatePassword, certificateAlias, version, ignoreSsl)));
+                    new CertificateAuthenticator(networkAddress, certificateData, certificatePassword, certificateAlias, version, ignoreSsl, null)));
+        }
+        
+        /**
+         *  Get a persistent event listener using a client certificate stored in memory.
+         *
+         *  @param networkAddress Network address of Safeguard appliance.
+         *  @param certificateData Bytes containing a PFX (or PKCS12) formatted certificate and private key.
+         *  @param certificatePassword Password to decrypt the certificate file.
+         *  @param certificateAlias Alias identifying a client certificate in the keystore.
+         *  @param apiVersion Target API version to use.
+         *  @param validationCallback Callback function to be executed during SSL certificate validation.
+         * 
+         *  @return New persistent Safeguard event listener.
+         *  @throws ObjectDisposedException Object has already been disposed.
+         *  @throws SafeguardForJavaException General Safeguard for Java
+         *  exception.
+         */
+        public static ISafeguardEventListener getPersistentEventListener(String networkAddress, byte[] certificateData,
+                char[] certificatePassword, String certificateAlias, HostnameVerifier validationCallback, Integer apiVersion)
+                throws ObjectDisposedException, SafeguardForJavaException {
+            int version = DEFAULTAPIVERSION;
+            if (apiVersion != null) {
+                version = apiVersion;
+            }
+
+            return new PersistentSafeguardEventListener(getConnection(
+                    new CertificateAuthenticator(networkAddress, certificateData, certificatePassword, certificateAlias, version, false, validationCallback)));
         }
         
         /**
@@ -342,7 +586,34 @@ public final class Safeguard {
             }
 
             return new PersistentSafeguardEventListener(getConnection(new CertificateAuthenticator(networkAddress,
-                    keystorePath, keystorePassword, certificateAlias, version, ignoreSsl)));
+                    keystorePath, keystorePassword, certificateAlias, version, ignoreSsl, null)));
+        }
+        
+        /**
+         *  Get a persistent event listener using a client certificate from the
+         *  certificate keystore for authentication.
+         *
+         *  @param networkAddress Network address of Safeguard appliance.
+         *  @param keystorePath Path to the keystore containing the client certificate.
+         *  @param keystorePassword Keystore password.
+         *  @param certificateAlias Alias identifying a client certificate in the keystore.
+         *  @param apiVersion Target API version to use.
+         *  @param validationCallback Callback function to be executed during SSL certificate validation.
+         * 
+         *  @return New persistent Safeguard event listener.
+         *  @throws ObjectDisposedException Object has already been disposed.
+         *  @throws SafeguardForJavaException General Safeguard for Java exception.
+         */
+        public static ISafeguardEventListener getPersistentEventListener(String networkAddress,
+                String keystorePath, char[] keystorePassword, String certificateAlias, HostnameVerifier validationCallback, Integer apiVersion)
+                throws ObjectDisposedException, SafeguardForJavaException {
+            int version = DEFAULTAPIVERSION;
+            if (apiVersion != null) {
+                version = apiVersion;
+            }
+
+            return new PersistentSafeguardEventListener(getConnection(new CertificateAuthenticator(networkAddress,
+                    keystorePath, keystorePassword, certificateAlias, version, false, validationCallback)));
         }
     }
 
@@ -376,7 +647,29 @@ public final class Safeguard {
                 sslIgnore = ignoreSsl;
             }
 
-            return new SafeguardA2AContext(networkAddress, certificateAlias, keystorePath, keystorePassword, version, sslIgnore);
+            return new SafeguardA2AContext(networkAddress, certificateAlias, keystorePath, keystorePassword, version, sslIgnore, null);
+        }
+
+        /**
+         *  Establish a Safeguard A2A context using a client certificate from the keystore.
+         *
+         *  @param networkAddress Network address of Safeguard appliance.
+         *  @param keystorePath Path to the keystore containing the client certificate.
+         *  @param keystorePassword Keystore password.
+         *  @param certificateAlias Alias identifying a client certificate in the keystore.
+         *  @param apiVersion Target API version to use.
+         *  @param validationCallback Callback function to be executed during SSL certificate validation.
+         * 
+         *  @return Reusable Safeguard A2A context.
+         */
+        public static ISafeguardA2AContext getContext(String networkAddress, String keystorePath, char[] keystorePassword, String certificateAlias,
+                HostnameVerifier validationCallback, Integer apiVersion) {
+            int version = DEFAULTAPIVERSION;
+            if (apiVersion != null) {
+                version = apiVersion;
+            }
+
+            return new SafeguardA2AContext(networkAddress, certificateAlias, keystorePath, keystorePassword, version, false, validationCallback);
         }
 
         /**
@@ -403,7 +696,29 @@ public final class Safeguard {
                 sslIgnore = ignoreSsl;
             }
 
-            return new SafeguardA2AContext(networkAddress, certificatePath, certificatePassword, version, sslIgnore);
+            return new SafeguardA2AContext(networkAddress, certificatePath, certificatePassword, version, sslIgnore, null);
+        }
+
+        /**
+         *  Establish a Safeguard A2A context using a client certificate stored in a file.
+         *
+         *  @param networkAddress Network address of Safeguard appliance.
+         *  @param certificatePath Path to PFX (or PKCS12) certificate file also
+         *  containing private key.
+         *  @param certificatePassword Password to decrypt the certificate file.
+         *  @param apiVersion Target API version to use.
+         *  @param validationCallback Callback function to be executed during SSL certificate validation.
+         * 
+         *  @return Reusable Safeguard A2A context.
+         */
+        public static ISafeguardA2AContext getContext(String networkAddress, String certificatePath,
+                char[] certificatePassword, HostnameVerifier validationCallback, Integer apiVersion) {
+            int version = DEFAULTAPIVERSION;
+            if (apiVersion != null) {
+                version = apiVersion;
+            }
+
+            return new SafeguardA2AContext(networkAddress, certificatePath, certificatePassword, version, false, validationCallback);
         }
 
         /**
@@ -429,7 +744,28 @@ public final class Safeguard {
                 sslIgnore = ignoreSsl;
             }
 
-            return new SafeguardA2AContext(networkAddress, certificateData, certificatePassword, version, sslIgnore);
+            return new SafeguardA2AContext(networkAddress, certificateData, certificatePassword, version, sslIgnore, null);
+        }
+        
+        /**
+         *  Establish a Safeguard A2A context using a client certificate stored in memory.
+         *
+         *  @param networkAddress Network address of Safeguard appliance.
+         *  @param certificateData Bytes containing a PFX (or PKCS12) formatted certificate and private key.
+         *  @param certificatePassword Password to decrypt the certificate file.
+         *  @param apiVersion Target API version to use.
+         *  @param validationCallback Callback function to be executed during SSL certificate validation.
+         * 
+         *  @return Reusable Safeguard A2A context.
+         */
+        public static ISafeguardA2AContext getContext(String networkAddress, byte[] certificateData,
+                char[] certificatePassword, HostnameVerifier validationCallback, Integer apiVersion) {
+            int version = DEFAULTAPIVERSION;
+            if (apiVersion != null) {
+                version = apiVersion;
+            }
+
+            return new SafeguardA2AContext(networkAddress, certificateData, certificatePassword, version, false, validationCallback);
         }
         
         /**
@@ -479,7 +815,44 @@ public final class Safeguard {
                 }
 
                 return new PersistentSafeguardA2AEventListener(
-                        new SafeguardA2AContext(networkAddress, certificateAlias, keystorePath, keystorePassword, version, ignoreSsl),
+                        new SafeguardA2AContext(networkAddress, certificateAlias, keystorePath, keystorePassword, version, ignoreSsl, null),
+                        apiKey, handler);
+            }
+
+            /**
+             *  Get a persistent A2A event listener for Gets an A2A event
+             *  listener. The handler passed in will be registered for the
+             *  AssetAccountPasswordUpdated event, which is the only one
+             *  supported in A2A. Uses a client certificate the keystore.
+             *
+             *  @param apiKey API key corresponding to the configured account to
+             *  listen for.
+             *  @param handler A delegate to call any time the
+             *  AssetAccountPasswordUpdate event occurs.
+             *  @param networkAddress Network address of Safeguard appliance.
+             *  @param keystorePath Path to the keystore containing the client
+             *  certificate.
+             *  @param keystorePassword Keystore password.
+             *  @param certificateAlias Alias identifying a client certificate in
+             *  the keystore.
+             *  @param apiVersion Target API version to use.
+             *  @param validationCallback Callback function to be executed during SSL certificate validation.
+             * 
+             *  @return New persistent A2A event listener.
+             *  @throws ObjectDisposedException Object has already been disposed.
+             *  @throws ArgumentException Invalid argument.
+             */
+            public static ISafeguardEventListener getPersistentA2AEventListener(char[] apiKey, ISafeguardEventHandler handler,
+                    String networkAddress, String keystorePath, char[] keystorePassword, String certificateAlias,
+                    HostnameVerifier validationCallback, Integer apiVersion)
+                    throws ObjectDisposedException, ArgumentException {
+                int version = DEFAULTAPIVERSION;
+                if (apiVersion != null) {
+                    version = apiVersion;
+                }
+
+                return new PersistentSafeguardA2AEventListener(
+                        new SafeguardA2AContext(networkAddress, certificateAlias, keystorePath, keystorePassword, version, false, validationCallback),
                         apiKey, handler);
             }
 
@@ -521,7 +894,43 @@ public final class Safeguard {
 
                 return new PersistentSafeguardA2AEventListener(
                         new SafeguardA2AContext(networkAddress, certificatePath, certificatePassword, version,
-                                ignoreSsl), apiKey, handler);
+                                ignoreSsl, null), apiKey, handler);
+            }
+            
+            /**
+             *  Get a persistent A2A event listener for Gets an A2A event
+             *  listener. The handler passed in will be registered for the
+             *  AssetAccountPasswordUpdated event, which is the only one
+             *  supported in A2A. Uses a client certificate from a file.
+             *
+             *  @param apiKey API key corresponding to the configured account to
+             *  listen for.
+             *  @param handler A delegate to call any time the
+             *  AssetAccountPasswordUpdate event occurs.
+             *  @param networkAddress Network address of Safeguard appliance.
+             *  @param certificatePath Path to PFX (or PKCS12) certificate file
+             *  also containing private key.
+             *  @param certificatePassword Password to decrypt the certificate file.
+             *  @param apiVersion Target API version to use.
+             *  @param validationCallback Callback function to be executed during SSL certificate validation.
+             * 
+             *  @return New persistent A2A event listener.
+             *  @throws ObjectDisposedException Object has already been disposed.
+             *  @throws ArgumentException Invalid argument.
+             */
+            public static ISafeguardEventListener getPersistentA2AEventListener(char[] apiKey,
+                    ISafeguardEventHandler handler, String networkAddress, String certificatePath,
+                    char[] certificatePassword, HostnameVerifier validationCallback, Integer apiVersion)
+                    throws ObjectDisposedException, ArgumentException {
+                
+                int version = DEFAULTAPIVERSION;
+                if (apiVersion != null) {
+                    version = apiVersion;
+                }
+
+                return new PersistentSafeguardA2AEventListener(
+                        new SafeguardA2AContext(networkAddress, certificatePath, certificatePassword, version,
+                                false, validationCallback), apiKey, handler);
             }
             
             /**
@@ -561,7 +970,42 @@ public final class Safeguard {
 
                 return new PersistentSafeguardA2AEventListener(
                         new SafeguardA2AContext(networkAddress, certificateData, certificatePassword, version,
-                                ignoreSsl), apiKey, handler);
+                                ignoreSsl, null), apiKey, handler);
+            }
+            
+            /**
+             *  Get a persistent A2A event listener for Gets an A2A event
+             *  listener. The handler passed in will be registered for the
+             *  AssetAccountPasswordUpdated event, which is the only one
+             *  supported in A2A. Uses a client certificate stored in memory.
+             *
+             *  @param apiKey API key corresponding to the configured account to
+             *  listen for.
+             *  @param handler A delegate to call any time the
+             *  AssetAccountPasswordUpdate event occurs.
+             *  @param networkAddress Network address of Safeguard appliance.
+             *  @param certificateData Bytes containing a PFX (or PKCS12) formatted certificate and private key.
+             *  @param certificatePassword Password to decrypt the certificate file.
+             *  @param apiVersion Target API version to use.
+             *  @param validationCallback Callback function to be executed during SSL certificate validation.
+             * 
+             *  @return New persistent A2A event listener.
+             *  @throws ObjectDisposedException Object has already been disposed.
+             *  @throws ArgumentException Invalid argument.
+             */
+            public static ISafeguardEventListener getPersistentA2AEventListener(char[] apiKey,
+                    ISafeguardEventHandler handler, String networkAddress, byte[] certificateData,
+                    char[] certificatePassword, HostnameVerifier validationCallback, Integer apiVersion)
+                    throws ObjectDisposedException, ArgumentException {
+                
+                int version = DEFAULTAPIVERSION;
+                if (apiVersion != null) {
+                    version = apiVersion;
+                }
+
+                return new PersistentSafeguardA2AEventListener(
+                        new SafeguardA2AContext(networkAddress, certificateData, certificatePassword, version,
+                                false, validationCallback), apiKey, handler);
             }
             
             /**
@@ -602,7 +1046,44 @@ public final class Safeguard {
                 }
 
                 return new PersistentSafeguardA2AEventListener(
-                        new SafeguardA2AContext(networkAddress, certificateAlias, keystorePath, keystorePassword, version, ignoreSsl),
+                        new SafeguardA2AContext(networkAddress, certificateAlias, keystorePath, keystorePassword, version, ignoreSsl, null),
+                        apiKeys, handler);
+            }
+
+            /**
+             *  Get a persistent A2A event listener for Gets an A2A event
+             *  listener. The handler passed in will be registered for the
+             *  AssetAccountPasswordUpdated event, which is the only one
+             *  supported in A2A. Uses a client certificate from a keystore.
+             *
+             *  @param apiKeys A list of API keys corresponding to the configured accounts to
+             *  listen for.
+             *  @param handler A delegate to call any time the
+             *  AssetAccountPasswordUpdate event occurs.
+             *  @param networkAddress Network address of Safeguard appliance.
+             *  @param keystorePath Path to the keystore containing the client
+             *  certificate.
+             *  @param keystorePassword Keystore password.
+             *  @param certificateAlias Alias identifying a client certificate in
+             *  the keystore.
+             *  @param apiVersion Target API version to use.
+             *  @param validationCallback Callback function to be executed during SSL certificate validation.
+             * 
+             *  @return New persistent A2A event listener.
+             *  @throws ObjectDisposedException Object has already been disposed.
+             *  @throws ArgumentException Invalid argument.
+             */
+            public static ISafeguardEventListener getPersistentA2AEventListener(List<char[]> apiKeys, ISafeguardEventHandler handler,
+                    String networkAddress, String keystorePath, char[] keystorePassword, String certificateAlias,
+                    HostnameVerifier validationCallback, Integer apiVersion)
+                    throws ObjectDisposedException, ArgumentException {
+                int version = DEFAULTAPIVERSION;
+                if (apiVersion != null) {
+                    version = apiVersion;
+                }
+
+                return new PersistentSafeguardA2AEventListener(
+                        new SafeguardA2AContext(networkAddress, certificateAlias, keystorePath, keystorePassword, version, false, validationCallback),
                         apiKeys, handler);
             }
 
@@ -644,7 +1125,43 @@ public final class Safeguard {
 
                 return new PersistentSafeguardA2AEventListener(
                         new SafeguardA2AContext(networkAddress, certificatePath, certificatePassword, version,
-                                ignoreSsl), apiKeys, handler);
+                                ignoreSsl, null), apiKeys, handler);
+            }
+            
+            /**
+             *  Get a persistent A2A event listener for Gets an A2A event
+             *  listener. The handler passed in will be registered for the
+             *  AssetAccountPasswordUpdated event, which is the only one
+             *  supported in A2A. Uses a client certificate stored in a file.
+             *
+             *  @param apiKeys A list of API key corresponding to the configured accounts to
+             *  listen for.
+             *  @param handler A delegate to call any time the
+             *  AssetAccountPasswordUpdate event occurs.
+             *  @param networkAddress Network address of Safeguard appliance.
+             *  @param certificatePath Path to PFX (or PKCS12) certificate file
+             *  also containing private key.
+             *  @param certificatePassword Password to decrypt the certificate file.
+             *  @param apiVersion Target API version to use.
+             *  @param validationCallback Callback function to be executed during SSL certificate validation.
+             * 
+             *  @return New persistent A2A event listener.
+             *  @throws ObjectDisposedException Object has already been disposed.
+             *  @throws ArgumentException Invalid argument.
+             */
+            public static ISafeguardEventListener getPersistentA2AEventListener(List<char[]> apiKeys,
+                    ISafeguardEventHandler handler, String networkAddress, String certificatePath,
+                    char[] certificatePassword, HostnameVerifier validationCallback, Integer apiVersion)
+                    throws ObjectDisposedException, ArgumentException {
+                
+                int version = DEFAULTAPIVERSION;
+                if (apiVersion != null) {
+                    version = apiVersion;
+                }
+
+                return new PersistentSafeguardA2AEventListener(
+                        new SafeguardA2AContext(networkAddress, certificatePath, certificatePassword, version,
+                                false, validationCallback), apiKeys, handler);
             }
             
             /**
@@ -684,7 +1201,42 @@ public final class Safeguard {
 
                 return new PersistentSafeguardA2AEventListener(
                         new SafeguardA2AContext(networkAddress, certificateData, certificatePassword, version,
-                                ignoreSsl), apiKeys, handler);
+                                ignoreSsl, null), apiKeys, handler);
+            }
+            
+            /**
+             *  Get a persistent A2A event listener for Gets an A2A event
+             *  listener. The handler passed in will be registered for the
+             *  AssetAccountPasswordUpdated event, which is the only one
+             *  supported in A2A. Uses a client certificate stored in memory.
+             *
+             *  @param apiKeys A list of API key corresponding to the configured accounts to
+             *  listen for.
+             *  @param handler A delegate to call any time the
+             *  AssetAccountPasswordUpdate event occurs.
+             *  @param networkAddress Network address of Safeguard appliance.
+             *  @param certificateData Bytes containing a PFX (or PKCS12) formatted certificate and private key.
+             *  @param certificatePassword Password to decrypt the certificate file.
+             *  @param apiVersion Target API version to use.
+             *  @param validationCallback Callback function to be executed during SSL certificate validation.
+             * 
+             *  @return New persistent A2A event listener.
+             *  @throws ObjectDisposedException Object has already been disposed.
+             *  @throws ArgumentException Invalid argument.
+             */
+            public static ISafeguardEventListener getPersistentA2AEventListener(List<char[]> apiKeys,
+                    ISafeguardEventHandler handler, String networkAddress, byte[] certificateData,
+                    char[] certificatePassword, HostnameVerifier validationCallback, Integer apiVersion)
+                    throws ObjectDisposedException, ArgumentException {
+                
+                int version = DEFAULTAPIVERSION;
+                if (apiVersion != null) {
+                    version = apiVersion;
+                }
+
+                return new PersistentSafeguardA2AEventListener(
+                        new SafeguardA2AContext(networkAddress, certificateData, certificatePassword, version,
+                                false, validationCallback), apiKeys, handler);
             }
         }
     }

--- a/src/main/java/com/oneidentity/safeguard/safeguardjava/SafeguardConnection.java
+++ b/src/main/java/com/oneidentity/safeguard/safeguardjava/SafeguardConnection.java
@@ -37,15 +37,15 @@ class SafeguardConnection implements ISafeguardConnection {
 
         String safeguardCoreUrl = String.format("https://%s/service/core/v%d",
                 this.authenticationMechanism.getNetworkAddress(), this.authenticationMechanism.getApiVersion());
-        coreClient = new RestClient(safeguardCoreUrl, authenticationMechanism.isIgnoreSsl());
+        coreClient = new RestClient(safeguardCoreUrl, authenticationMechanism.isIgnoreSsl(), authenticationMechanism.getValidationCallback());
 
         String safeguardApplianceUrl = String.format("https://%s/service/appliance/v%d",
                 this.authenticationMechanism.getNetworkAddress(), this.authenticationMechanism.getApiVersion());
-        applianceClient = new RestClient(safeguardApplianceUrl, authenticationMechanism.isIgnoreSsl());
+        applianceClient = new RestClient(safeguardApplianceUrl, authenticationMechanism.isIgnoreSsl(), authenticationMechanism.getValidationCallback());
 
         String safeguardNotificationUrl = String.format("https://%s/service/notification/v%d",
                 this.authenticationMechanism.getNetworkAddress(), this.authenticationMechanism.getApiVersion());
-        notificationClient = new RestClient(safeguardNotificationUrl, authenticationMechanism.isIgnoreSsl());
+        notificationClient = new RestClient(safeguardNotificationUrl, authenticationMechanism.isIgnoreSsl(), authenticationMechanism.getValidationCallback());
     }
 
     @Override
@@ -164,7 +164,7 @@ class SafeguardConnection implements ISafeguardConnection {
     public SafeguardEventListener getEventListener() throws ObjectDisposedException, ArgumentException {
         SafeguardEventListener eventListener = new SafeguardEventListener(
                 String.format("https://%s/service/event", authenticationMechanism.getNetworkAddress()),
-                authenticationMechanism.getAccessToken(), authenticationMechanism.isIgnoreSsl());
+                authenticationMechanism.getAccessToken(), authenticationMechanism.isIgnoreSsl(), authenticationMechanism.getValidationCallback());
         Logger.getLogger(SafeguardConnection.class.getName()).log(Level.FINEST, "Event listener successfully created for Safeguard connection.");
 
         return eventListener;

--- a/src/main/java/com/oneidentity/safeguard/safeguardjava/authentication/AccessTokenAuthenticator.java
+++ b/src/main/java/com/oneidentity/safeguard/safeguardjava/authentication/AccessTokenAuthenticator.java
@@ -2,15 +2,16 @@ package com.oneidentity.safeguard.safeguardjava.authentication;
 
 import com.oneidentity.safeguard.safeguardjava.exceptions.ArgumentException;
 import com.oneidentity.safeguard.safeguardjava.exceptions.SafeguardForJavaException;
+import javax.net.ssl.HostnameVerifier;
 
 public class AccessTokenAuthenticator extends AuthenticatorBase
 {
     private boolean disposed;
 
     public AccessTokenAuthenticator(String networkAddress, char[] accessToken,
-        int apiVersion, boolean ignoreSsl) throws ArgumentException
+        int apiVersion, boolean ignoreSsl, HostnameVerifier validationCallback) throws ArgumentException
     {
-        super(networkAddress, apiVersion, ignoreSsl);
+        super(networkAddress, apiVersion, ignoreSsl, validationCallback);
         if (accessToken == null)
             throw new ArgumentException("The accessToken parameter can not be null");
         

--- a/src/main/java/com/oneidentity/safeguard/safeguardjava/authentication/AnonymousAuthenticator.java
+++ b/src/main/java/com/oneidentity/safeguard/safeguardjava/authentication/AnonymousAuthenticator.java
@@ -1,13 +1,38 @@
 package com.oneidentity.safeguard.safeguardjava.authentication;
 
+import com.oneidentity.safeguard.safeguardjava.Utils;
 import com.oneidentity.safeguard.safeguardjava.exceptions.SafeguardForJavaException;
+import com.oneidentity.safeguard.safeguardjava.restclient.RestClient;
+import java.util.HashMap;
+import java.util.Map;
+import javax.net.ssl.HostnameVerifier;
+import org.apache.http.client.methods.CloseableHttpResponse;
 
 public class AnonymousAuthenticator extends AuthenticatorBase {
 
     private boolean disposed;
 
-    public AnonymousAuthenticator(String networkAddress, int apiVersion, boolean ignoreSsl) {
-        super(networkAddress, apiVersion, ignoreSsl);
+    public AnonymousAuthenticator(String networkAddress, int apiVersion, boolean ignoreSsl, HostnameVerifier validationCallback) throws SafeguardForJavaException {
+        super(networkAddress, apiVersion, ignoreSsl, validationCallback);
+        
+        String notificationUrl = String.format("https://%s/service/notification/v%d", networkAddress, apiVersion);
+        RestClient notificationClient = new RestClient(notificationUrl, ignoreSsl, validationCallback);
+        
+        Map<String,String> headers = new HashMap<>();
+        headers.put("Accept", "application/json");
+        headers.put("Content-type", "application/json");
+        CloseableHttpResponse response = notificationClient.execGET("Status", null, headers);
+
+        if (response == null) {
+            throw new SafeguardForJavaException(String.format("Unable to anonymously connect to web service %s", notificationClient.getBaseURL()));
+        }
+        
+        String reply = Utils.getResponse(response);
+
+        if (!Utils.isSuccessful(response.getStatusLine().getStatusCode())) {
+            throw new SafeguardForJavaException("Unable to anonymously connect to {networkAddress}, Error: "
+                    + String.format("%d %s", response.getStatusLine().getStatusCode(), reply));
+        }
     }
 
     @Override

--- a/src/main/java/com/oneidentity/safeguard/safeguardjava/authentication/CertificateAuthenticator.java
+++ b/src/main/java/com/oneidentity/safeguard/safeguardjava/authentication/CertificateAuthenticator.java
@@ -6,6 +6,7 @@ import com.oneidentity.safeguard.safeguardjava.data.OauthBody;
 import com.oneidentity.safeguard.safeguardjava.exceptions.ObjectDisposedException;
 import com.oneidentity.safeguard.safeguardjava.exceptions.SafeguardForJavaException;
 import java.util.Map;
+import javax.net.ssl.HostnameVerifier;
 import org.apache.http.client.methods.CloseableHttpResponse;
 
 public class CertificateAuthenticator extends AuthenticatorBase
@@ -15,29 +16,30 @@ public class CertificateAuthenticator extends AuthenticatorBase
     private final CertificateContext clientCertificate;
 
     public CertificateAuthenticator(String networkAddress, String keystorePath, char[] keystorePassword, String certificateAlias, 
-            int apiVersion, boolean ignoreSsl)
+            int apiVersion, boolean ignoreSsl, HostnameVerifier validationCallback)
     {
-        super(networkAddress, apiVersion, ignoreSsl);
+        super(networkAddress, apiVersion, ignoreSsl, validationCallback);
         clientCertificate = new CertificateContext(certificateAlias, keystorePath, null, keystorePassword);
     }
 
     public CertificateAuthenticator(String networkAddress, String certificatePath, char[] certificatePassword,
-            int apiVersion, boolean ignoreSsl) {
+            int apiVersion, boolean ignoreSsl, HostnameVerifier validationCallback) {
         
-        super(networkAddress, apiVersion, ignoreSsl);
+        super(networkAddress, apiVersion, ignoreSsl, validationCallback);
         clientCertificate = new CertificateContext(null, certificatePath, null, certificatePassword);
     }
 
     public CertificateAuthenticator(String networkAddress, byte[] certificateData, char[] certificatePassword, String certificateAlias,
-            int apiVersion, boolean ignoreSsl) {
+            int apiVersion, boolean ignoreSsl, HostnameVerifier validationCallback) {
         
-        super(networkAddress, apiVersion, ignoreSsl);
+        super(networkAddress, apiVersion, ignoreSsl, validationCallback);
         clientCertificate = new CertificateContext(certificateAlias, null, certificateData, certificatePassword);
     }
     
-    private CertificateAuthenticator(String networkAddress, CertificateContext clientCertificate, int apiVersion, boolean ignoreSsl) {
+    private CertificateAuthenticator(String networkAddress, CertificateContext clientCertificate, 
+            int apiVersion, boolean ignoreSsl, HostnameVerifier validationCallback) {
         
-        super(networkAddress, apiVersion, ignoreSsl);
+        super(networkAddress, apiVersion, ignoreSsl, validationCallback);
         this.clientCertificate = clientCertificate.cloneObject();
     }
     
@@ -80,7 +82,8 @@ public class CertificateAuthenticator extends AuthenticatorBase
 
     @Override
     public Object cloneObject() throws SafeguardForJavaException {
-        CertificateAuthenticator auth = new CertificateAuthenticator(this.getNetworkAddress(), clientCertificate, this.getApiVersion(), this.isIgnoreSsl());
+        CertificateAuthenticator auth = new CertificateAuthenticator(this.getNetworkAddress(), clientCertificate, 
+                this.getApiVersion(), this.isIgnoreSsl(), this.getValidationCallback());
         if (this.accessToken != null) {
             auth.accessToken = this.accessToken.clone();
         }

--- a/src/main/java/com/oneidentity/safeguard/safeguardjava/authentication/IAuthenticationMechanism.java
+++ b/src/main/java/com/oneidentity/safeguard/safeguardjava/authentication/IAuthenticationMechanism.java
@@ -2,6 +2,7 @@ package com.oneidentity.safeguard.safeguardjava.authentication;
 
 import com.oneidentity.safeguard.safeguardjava.exceptions.ObjectDisposedException;
 import com.oneidentity.safeguard.safeguardjava.exceptions.SafeguardForJavaException;
+import javax.net.ssl.HostnameVerifier;
 
 
 public interface IAuthenticationMechanism
@@ -15,6 +16,7 @@ public interface IAuthenticationMechanism
     void clearAccessToken();
     char[] getAccessToken() throws ObjectDisposedException;
     int getAccessTokenLifetimeRemaining() throws ObjectDisposedException, SafeguardForJavaException;
+    HostnameVerifier getValidationCallback();
     void refreshAccessToken() throws ObjectDisposedException, SafeguardForJavaException;
     Object cloneObject() throws SafeguardForJavaException;
     void dispose();

--- a/src/main/java/com/oneidentity/safeguard/safeguardjava/authentication/PasswordAuthenticator.java
+++ b/src/main/java/com/oneidentity/safeguard/safeguardjava/authentication/PasswordAuthenticator.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.net.ssl.HostnameVerifier;
 import org.apache.http.client.methods.CloseableHttpResponse;
 
 public class PasswordAuthenticator extends AuthenticatorBase 
@@ -29,9 +30,10 @@ public class PasswordAuthenticator extends AuthenticatorBase
     private final char[] password;
 
     public PasswordAuthenticator(String networkAddress, String provider, String username,
-        char[] password, int apiVersion, boolean ignoreSsl) throws ArgumentException
+            char[] password, int apiVersion, boolean ignoreSsl, HostnameVerifier validationCallback) 
+            throws ArgumentException
     {
-        super(networkAddress, apiVersion, ignoreSsl);
+        super(networkAddress, apiVersion, ignoreSsl, validationCallback);
         this.provider = provider;
         
         if (Utils.isNullOrEmpty(this.provider) || this.provider.equalsIgnoreCase("local"))
@@ -91,6 +93,9 @@ public class PasswordAuthenticator extends AuthenticatorBase
                     throw new SafeguardForJavaException(String.format("Unable to find scope matching '%s' in [%s]", provider, String.join(",", knownScopes)));
             }
         }
+        catch (SafeguardForJavaException ex) {
+            throw ex;
+        }
         catch (Exception ex)
         {
             throw new SafeguardForJavaException("Unable to connect to determine identity provider", ex);
@@ -128,7 +133,8 @@ public class PasswordAuthenticator extends AuthenticatorBase
     public Object cloneObject() throws SafeguardForJavaException
     {
         try {
-            PasswordAuthenticator auth = new PasswordAuthenticator(getNetworkAddress(), provider, username, password, getApiVersion(), isIgnoreSsl());
+            PasswordAuthenticator auth = new PasswordAuthenticator(getNetworkAddress(), provider, username, password, 
+                    getApiVersion(), isIgnoreSsl(), getValidationCallback());
             auth.accessToken = this.accessToken == null ? null : this.accessToken.clone();
             return auth;
         } catch (ArgumentException ex) {


### PR DESCRIPTION
Add a HostnameVerifier callback so that the caller can implement their own ssl certificate validation.  How it is done is different from C# but the concept is the same.