### PR TITLE
Update SafeguardJava to the same functionality as SafeguardDotNet.  

### DIFF
--- a/src/main/java/com/oneidentity/safeguard/safeguardjava/ISafeguardA2AContext.java
+++ b/src/main/java/com/oneidentity/safeguard/safeguardjava/ISafeguardA2AContext.java
@@ -2,6 +2,7 @@ package com.oneidentity.safeguard.safeguardjava;
 
 import com.oneidentity.safeguard.safeguardjava.data.A2ARetrievableAccount;
 import com.oneidentity.safeguard.safeguardjava.data.BrokeredAccessRequest;
+import com.oneidentity.safeguard.safeguardjava.data.KeyFormat;
 import com.oneidentity.safeguard.safeguardjava.event.ISafeguardEventListener;
 import com.oneidentity.safeguard.safeguardjava.exceptions.ArgumentException;
 import com.oneidentity.safeguard.safeguardjava.exceptions.ObjectDisposedException;
@@ -35,6 +36,15 @@ public interface ISafeguardA2AContext
      *  @throws ArgumentException Invalid argument.
      */
     char[] retrievePassword(char[] apiKey) throws ObjectDisposedException, SafeguardForJavaException, ArgumentException;
+
+    /**
+     *  Retrieves an SSH private key using Safeguard A2A.
+     *
+     *  @param apiKey    API key corresponding to the configured account.
+     *  @param keyFormat Format to use when returning private key.
+     *  return           The SSH private key.
+     */ 
+    char[] retrievePrivateKey(char[] apiKey, KeyFormat keyFormat) throws ObjectDisposedException, SafeguardForJavaException, ArgumentException;
 
     /**
      *  Gets an A2A event listener. The handler passed in will be registered for the AssetAccountPasswordUpdated

--- a/src/main/java/com/oneidentity/safeguard/safeguardjava/Safeguard.java
+++ b/src/main/java/com/oneidentity/safeguard/safeguardjava/Safeguard.java
@@ -390,6 +390,265 @@ public final class Safeguard {
     }
     
     /**
+     *  Connect to Safeguard API using a certificate from the keystore. The
+     *  appropriate keystore must have been loaded in the java process.
+     *
+     *  @param networkAddress Network address of Safeguard appliance.
+     *  @param keystorePath Path to the keystore containing the client certificate.
+     *  @param keystorePassword Keystore password.
+     *  @param certificateAlias Alias identifying a client certificate in the keystore.
+     *  @param provider Safeguard authentication provider name (e.g. local).
+     *  @param apiVersion Target API version to use.
+     *  @param ignoreSsl Ignore server certificate validation.
+     * 
+     *  @return Reusable Safeguard API connection.
+     *  @throws ObjectDisposedException Object has already been disposed.
+     *  @throws SafeguardForJavaException General Safeguard for Java exception.
+     */
+    public static ISafeguardConnection connect(String networkAddress, String keystorePath, 
+            char[] keystorePassword, String certificateAlias, String provider,
+            Integer apiVersion, Boolean ignoreSsl) 
+            throws ObjectDisposedException, SafeguardForJavaException {
+        int version = DEFAULTAPIVERSION;
+        if (apiVersion != null) {
+            version = apiVersion;
+        }
+
+        boolean sslIgnore = false;
+        if (ignoreSsl != null) {
+            sslIgnore = ignoreSsl;
+        }
+
+        return getConnection(new CertificateAuthenticator(networkAddress, keystorePath, 
+                keystorePassword, certificateAlias, version, sslIgnore, null, provider));
+    }
+
+    /**
+     *  Connect to Safeguard API using a certificate from the keystore. The
+     *  appropriate keystore must have been loaded in the java process.
+     *
+     *  @param networkAddress Network address of Safeguard appliance.
+     *  @param keystorePath Path to the keystore containing the client certificate.
+     *  @param keystorePassword Keystore password.
+     *  @param certificateAlias Alias identifying a client certificate in the keystore.
+     *  @param provider Safeguard authentication provider name (e.g. local).
+     *  @param apiVersion Target API version to use.
+     *  @param validationCallback Callback function to be executed during SSL certificate validation.
+     * 
+     *  @return Reusable Safeguard API connection.
+     *  @throws ObjectDisposedException Object has already been disposed.
+     *  @throws SafeguardForJavaException General Safeguard for Java exception.
+     */
+    public static ISafeguardConnection connect(String networkAddress, String keystorePath, 
+            char[] keystorePassword, String certificateAlias,
+            HostnameVerifier validationCallback,  String provider, Integer apiVersion) 
+            throws ObjectDisposedException, SafeguardForJavaException {
+        int version = DEFAULTAPIVERSION;
+        if (apiVersion != null) {
+            version = apiVersion;
+        }
+
+        return getConnection(new CertificateAuthenticator(networkAddress, keystorePath, 
+                keystorePassword, certificateAlias, version, false, validationCallback, provider));
+    }
+
+    /**
+     *  Connect to Safeguard API using a certificate from the Windows 
+     *  certificate store. This is a Windows only API and requires that the
+     *  SunMSCAPI security provider is available in the Java environment.
+     *
+     *  @param networkAddress Network address of Safeguard appliance.
+     *  @param thumbprint Thumbprint of the client certificate.
+     *  @param provider Safeguard authentication provider name (e.g. local).
+     *  @param apiVersion Target API version to use.
+     *  @param ignoreSsl Ignore server certificate validation.
+     * 
+     *  @return Reusable Safeguard API connection.
+     *  @throws ObjectDisposedException Object has already been disposed.
+     *  @throws SafeguardForJavaException General Safeguard for Java exception.
+     */
+    public static ISafeguardConnection connect(String networkAddress, String thumbprint, 
+             String provider, Integer apiVersion, Boolean ignoreSsl) 
+            throws ObjectDisposedException, SafeguardForJavaException {
+        int version = DEFAULTAPIVERSION;
+        if (apiVersion != null) {
+            version = apiVersion;
+        }
+
+        boolean sslIgnore = false;
+        if (ignoreSsl != null) {
+            sslIgnore = ignoreSsl;
+        }
+
+        if (Utils.isWindows()) {
+            if (!Utils.isSunMSCAPILoaded()) {
+                throw new SafeguardForJavaException("Missing SunMSCAPI provider. The SunMSCAPI provider must be added as a security provider in $JAVA_HOME/jre/lib/security/java.security configuration file.");
+            }
+        }
+        else {
+            throw new SafeguardForJavaException("Not implemented. This function is only available on the Windows platform.");
+        }
+        
+        return getConnection(new CertificateAuthenticator(networkAddress, thumbprint, 
+                version, sslIgnore, null, provider));
+    }
+
+    /**
+     *  Connect to Safeguard API using a certificate from the Windows 
+     *  certificate store. This is a Windows only API and requires that the
+     *  SunMSCAPI security provider is available in the Java environment.
+     *
+     *  @param networkAddress Network address of Safeguard appliance.
+     *  @param thumbprint Thumbprint of the client certificate.
+     *  @param provider Safeguard authentication provider name (e.g. local).
+     *  @param apiVersion Target API version to use.
+     *  @param validationCallback Callback function to be executed during SSL certificate validation.
+     * 
+     *  @return Reusable Safeguard API connection.
+     *  @throws ObjectDisposedException Object has already been disposed.
+     *  @throws SafeguardForJavaException General Safeguard for Java exception.
+     */
+    public static ISafeguardConnection connect(String networkAddress, String thumbprint, 
+            HostnameVerifier validationCallback,  String provider, Integer apiVersion) 
+            throws ObjectDisposedException, SafeguardForJavaException {
+        int version = DEFAULTAPIVERSION;
+        if (apiVersion != null) {
+            version = apiVersion;
+        }
+
+        if (Utils.isWindows()) {
+            if (!Utils.isSunMSCAPILoaded()) {
+                throw new SafeguardForJavaException("Missing SunMSCAPI provider. The SunMSCAPI provider must be added as a security provider in $JAVA_HOME/jre/lib/security/java.security configuration file.");
+            }
+        }
+        else {
+            throw new SafeguardForJavaException("Not implemented. This function is only available on the Windows platform.");
+        }
+        
+        return getConnection(new CertificateAuthenticator(networkAddress, thumbprint, 
+                version, false, validationCallback, provider));
+    }
+
+    /**
+     *  Connect to Safeguard API using a certificate stored in a file.
+     *
+     *  @param networkAddress Network address of Safeguard appliance.
+     *  @param certificatePath Path to PFX (or PKCS12) certificate file also
+     *  containing private key.
+     *  @param certificatePassword Password to decrypt the certificate file.
+     *  @param apiVersion Target API version to use.
+     *  @param ignoreSsl Ignore server certificate validation.
+     *  @param provider Safeguard authentication provider name (e.g. local).
+     * 
+     *  @return Reusable Safeguard API connection.
+     *  @throws ObjectDisposedException Object has already been disposed.
+     *  @throws SafeguardForJavaException General Safeguard for Java exception.
+     */
+    public static ISafeguardConnection connect(String networkAddress, String certificatePath,
+            char[] certificatePassword, Integer apiVersion, Boolean ignoreSsl, String provider) 
+            throws ObjectDisposedException, SafeguardForJavaException {
+        int version = DEFAULTAPIVERSION;
+        if (apiVersion != null) {
+            version = apiVersion;
+        }
+
+        boolean sslIgnore = false;
+        if (ignoreSsl != null) {
+            sslIgnore = ignoreSsl;
+        }
+
+        return getConnection(new CertificateAuthenticator(networkAddress, certificatePath, certificatePassword,
+                version, sslIgnore, null, provider));
+    }
+
+    /**
+     *  Connect to Safeguard API using a certificate stored in a file.
+     *
+     *  @param networkAddress Network address of Safeguard appliance.
+     *  @param certificatePath Path to PFX (or PKCS12) certificate file also
+     *  containing private key.
+     *  @param certificatePassword Password to decrypt the certificate file.
+     *  @param provider Safeguard authentication provider name (e.g. local).
+     *  @param apiVersion Target API version to use.
+     *  @param validationCallback Callback function to be executed during SSL certificate validation.
+     * 
+     *  @return Reusable Safeguard API connection.
+     *  @throws ObjectDisposedException Object has already been disposed.
+     *  @throws SafeguardForJavaException General Safeguard for Java exception.
+     */
+    public static ISafeguardConnection connect(String networkAddress, String certificatePath,
+            char[] certificatePassword, HostnameVerifier validationCallback, String provider, Integer apiVersion) 
+            throws ObjectDisposedException, SafeguardForJavaException {
+        int version = DEFAULTAPIVERSION;
+        if (apiVersion != null) {
+            version = apiVersion;
+        }
+
+        return getConnection(new CertificateAuthenticator(networkAddress, certificatePath, certificatePassword,
+                version, false, validationCallback, provider));
+    }
+
+    /**
+     *  Connect to Safeguard API using a certificate stored in memory.
+     *
+     *  @param networkAddress Network address of Safeguard appliance.
+     *  @param certificateData Bytes containing a PFX (or PKCS12) formatted certificate and private key.
+     *  @param certificatePassword Password to decrypt the certificate data.
+     *  @param certificateAlias Alias identifying a client certificate in the keystore.
+     *  @param provider Safeguard authentication provider name (e.g. local).
+     *  @param apiVersion Target API version to use.
+     *  @param ignoreSsl Ignore server certificate validation.
+     * 
+     *  @return Reusable Safeguard API connection.
+     *  @throws ObjectDisposedException Object has already been disposed.
+     *  @throws SafeguardForJavaException General Safeguard for Java exception.
+     */
+    public static ISafeguardConnection connect(String networkAddress, byte[] certificateData,
+            char[] certificatePassword, String certificateAlias, String provider, Integer apiVersion, Boolean ignoreSsl) 
+            throws ObjectDisposedException, SafeguardForJavaException {
+        int version = DEFAULTAPIVERSION;
+        if (apiVersion != null) {
+            version = apiVersion;
+        }
+
+        boolean sslIgnore = false;
+        if (ignoreSsl != null) {
+            sslIgnore = ignoreSsl;
+        }
+
+        return getConnection(new CertificateAuthenticator(networkAddress, certificateData, certificatePassword, certificateAlias,
+                version, sslIgnore, null, provider));
+    }
+    
+    /**
+     *  Connect to Safeguard API using a certificate stored in memory.
+     *
+     *  @param networkAddress Network address of Safeguard appliance.
+     *  @param certificateData Bytes containing a PFX (or PKCS12) formatted certificate and private key.
+     *  @param certificatePassword Password to decrypt the certificate data.
+     *  @param certificateAlias Alias identifying a client certificate in the keystore.
+     *  @param provider Safeguard authentication provider name (e.g. local).
+     *  @param apiVersion Target API version to use.
+     *  @param validationCallback Callback function to be executed during SSL certificate validation.
+     * 
+     *  @return Reusable Safeguard API connection.
+     *  @throws ObjectDisposedException Object has already been disposed.
+     *  @throws SafeguardForJavaException General Safeguard for Java exception.
+     */
+    public static ISafeguardConnection connect(String networkAddress, byte[] certificateData,
+            char[] certificatePassword, String certificateAlias, HostnameVerifier validationCallback,
+            String provider, Integer apiVersion) 
+            throws ObjectDisposedException, SafeguardForJavaException {
+        int version = DEFAULTAPIVERSION;
+        if (apiVersion != null) {
+            version = apiVersion;
+        }
+
+        return getConnection(new CertificateAuthenticator(networkAddress, certificateData, certificatePassword, certificateAlias,
+                version, false, validationCallback, provider));
+    }
+    
+    /**
      *  Connect to Safeguard API anonymously.
      *
      *  @param networkAddress Network address.
@@ -689,6 +948,194 @@ public final class Safeguard {
 
             return new PersistentSafeguardEventListener(getConnection(new CertificateAuthenticator(networkAddress,
                     keystorePath, keystorePassword, certificateAlias, version, false, validationCallback)));
+        }
+
+        /**
+         *  Get a persistent event listener using a client certificate stored in
+         *  a file.
+         *
+         *  @param networkAddress Network address of Safeguard appliance.
+         *  @param certificatePath Path to PFX (or PKCS12) certificate file also
+         *  containing private key.
+         *  @param certificatePassword Password to decrypt the certificate file.
+         *  @param apiVersion Target API version to use.
+         *  @param ignoreSsl Ignore server certificate validation.
+         *  @param provider Safeguard authentication provider name (e.g. local).
+         * 
+         *  @return New persistent Safeguard event listener.
+         *  @throws ObjectDisposedException Object has already been disposed.
+         *  @throws SafeguardForJavaException General Safeguard for Java
+         *  exception.
+         */
+        public static ISafeguardEventListener getPersistentEventListener(String networkAddress, String certificatePath,
+                char[] certificatePassword, Integer apiVersion, Boolean ignoreSsl, String provider)
+                throws ObjectDisposedException, SafeguardForJavaException {
+            int version = DEFAULTAPIVERSION;
+            if (apiVersion != null) {
+                version = apiVersion;
+            }
+
+            boolean sslIgnore = false;
+            if (ignoreSsl != null) {
+                sslIgnore = ignoreSsl;
+            }
+
+            return new PersistentSafeguardEventListener(getConnection(
+                    new CertificateAuthenticator(networkAddress, certificatePath, certificatePassword, version, ignoreSsl, null, provider)));
+        }
+
+        /**
+         *  Get a persistent event listener using a client certificate stored in
+         *  a file.
+         *
+         *  @param networkAddress Network address of Safeguard appliance.
+         *  @param certificatePath Path to PFX (or PKCS12) certificate file also
+         *  containing private key.
+         *  @param certificatePassword Password to decrypt the certificate file.
+         *  @param provider Safeguard authentication provider name (e.g. local).
+         *  @param apiVersion Target API version to use.
+         *  @param validationCallback Callback function to be executed during SSL certificate validation.
+         * 
+         *  @return New persistent Safeguard event listener.
+         *  @throws ObjectDisposedException Object has already been disposed.
+         *  @throws SafeguardForJavaException General Safeguard for Java
+         *  exception.
+         */
+        public static ISafeguardEventListener getPersistentEventListener(String networkAddress, String certificatePath,
+                char[] certificatePassword, HostnameVerifier validationCallback, String provider, Integer apiVersion)
+                throws ObjectDisposedException, SafeguardForJavaException {
+            int version = DEFAULTAPIVERSION;
+            if (apiVersion != null) {
+                version = apiVersion;
+            }
+
+            return new PersistentSafeguardEventListener(getConnection(
+                    new CertificateAuthenticator(networkAddress, certificatePath, certificatePassword, version, false, validationCallback, provider)));
+        }
+
+        /**
+         *  Get a persistent event listener using a client certificate stored in memory.
+         *
+         *  @param networkAddress Network address of Safeguard appliance.
+         *  @param certificateData Bytes containing a PFX (or PKCS12) formatted certificate and private key.
+         *  @param certificatePassword Password to decrypt the certificate file.
+         *  @param certificateAlias Alias identifying a client certificate in the keystore.
+         *  @param provider Safeguard authentication provider name (e.g. local).
+         *  @param apiVersion Target API version to use.
+         *  @param ignoreSsl Ignore server certificate validation.
+         * 
+         *  @return New persistent Safeguard event listener.
+         *  @throws ObjectDisposedException Object has already been disposed.
+         *  @throws SafeguardForJavaException General Safeguard for Java
+         *  exception.
+         */
+        public static ISafeguardEventListener getPersistentEventListener(String networkAddress, byte[] certificateData,
+                char[] certificatePassword, String certificateAlias, String provider, Integer apiVersion, Boolean ignoreSsl)
+                throws ObjectDisposedException, SafeguardForJavaException {
+            int version = DEFAULTAPIVERSION;
+            if (apiVersion != null) {
+                version = apiVersion;
+            }
+
+            boolean sslIgnore = false;
+            if (ignoreSsl != null) {
+                sslIgnore = ignoreSsl;
+            }
+
+            return new PersistentSafeguardEventListener(getConnection(
+                    new CertificateAuthenticator(networkAddress, certificateData, certificatePassword, certificateAlias, version, ignoreSsl, null, provider)));
+        }
+        
+        /**
+         *  Get a persistent event listener using a client certificate stored in memory.
+         *
+         *  @param networkAddress Network address of Safeguard appliance.
+         *  @param certificateData Bytes containing a PFX (or PKCS12) formatted certificate and private key.
+         *  @param certificatePassword Password to decrypt the certificate file.
+         *  @param certificateAlias Alias identifying a client certificate in the keystore.
+         *  @param provider Safeguard authentication provider name (e.g. local).
+         *  @param apiVersion Target API version to use.
+         *  @param validationCallback Callback function to be executed during SSL certificate validation.
+         * 
+         *  @return New persistent Safeguard event listener.
+         *  @throws ObjectDisposedException Object has already been disposed.
+         *  @throws SafeguardForJavaException General Safeguard for Java
+         *  exception.
+         */
+        public static ISafeguardEventListener getPersistentEventListener(String networkAddress, byte[] certificateData,
+                char[] certificatePassword, String certificateAlias, HostnameVerifier validationCallback,
+                String provider, Integer apiVersion)
+                throws ObjectDisposedException, SafeguardForJavaException {
+            int version = DEFAULTAPIVERSION;
+            if (apiVersion != null) {
+                version = apiVersion;
+            }
+
+            return new PersistentSafeguardEventListener(getConnection(
+                    new CertificateAuthenticator(networkAddress, certificateData, certificatePassword, certificateAlias, version, false, validationCallback, provider)));
+        }
+        
+        /**
+         *  Get a persistent event listener using a client certificate from the
+         *  certificate keystore for authentication.
+         *
+         *  @param networkAddress Network address of Safeguard appliance.
+         *  @param keystorePath Path to the keystore containing the client certificate.
+         *  @param keystorePassword Keystore password.
+         *  @param certificateAlias Alias identifying a client certificate in the keystore.
+         *  @param provider Safeguard authentication provider name (e.g. local).
+         *  @param apiVersion Target API version to use.
+         *  @param ignoreSsl Ignore server certificate validation.
+         * 
+         *  @return New persistent Safeguard event listener.
+         *  @throws ObjectDisposedException Object has already been disposed.
+         *  @throws SafeguardForJavaException General Safeguard for Java exception.
+         */
+        public static ISafeguardEventListener getPersistentEventListener(String networkAddress,
+                String keystorePath, char[] keystorePassword, String certificateAlias,
+                String provider, Integer apiVersion, Boolean ignoreSsl)
+                throws ObjectDisposedException, SafeguardForJavaException {
+            int version = DEFAULTAPIVERSION;
+            if (apiVersion != null) {
+                version = apiVersion;
+            }
+
+            boolean sslIgnore = false;
+            if (ignoreSsl != null) {
+                sslIgnore = ignoreSsl;
+            }
+
+            return new PersistentSafeguardEventListener(getConnection(new CertificateAuthenticator(networkAddress,
+                    keystorePath, keystorePassword, certificateAlias, version, ignoreSsl, null, provider)));
+        }
+        
+        /**
+         *  Get a persistent event listener using a client certificate from the
+         *  certificate keystore for authentication.
+         *
+         *  @param networkAddress Network address of Safeguard appliance.
+         *  @param keystorePath Path to the keystore containing the client certificate.
+         *  @param keystorePassword Keystore password.
+         *  @param certificateAlias Alias identifying a client certificate in the keystore.
+         *  @param provider Safeguard authentication provider name (e.g. local).
+         *  @param apiVersion Target API version to use.
+         *  @param validationCallback Callback function to be executed during SSL certificate validation.
+         * 
+         *  @return New persistent Safeguard event listener.
+         *  @throws ObjectDisposedException Object has already been disposed.
+         *  @throws SafeguardForJavaException General Safeguard for Java exception.
+         */
+        public static ISafeguardEventListener getPersistentEventListener(String networkAddress,
+                String keystorePath, char[] keystorePassword, String certificateAlias, 
+                HostnameVerifier validationCallback, String provider, Integer apiVersion)
+                throws ObjectDisposedException, SafeguardForJavaException {
+            int version = DEFAULTAPIVERSION;
+            if (apiVersion != null) {
+                version = apiVersion;
+            }
+
+            return new PersistentSafeguardEventListener(getConnection(new CertificateAuthenticator(networkAddress,
+                    keystorePath, keystorePassword, certificateAlias, version, false, validationCallback, provider)));
         }
     }
 

--- a/src/main/java/com/oneidentity/safeguard/safeguardjava/SafeguardConnection.java
+++ b/src/main/java/com/oneidentity/safeguard/safeguardjava/SafeguardConnection.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import org.apache.http.HttpHeaders;
 import org.apache.http.client.methods.CloseableHttpResponse;
 
 class SafeguardConnection implements ISafeguardConnection {
@@ -155,7 +156,7 @@ class SafeguardConnection implements ISafeguardConnection {
         if (additionalHeaders == null) {
             additionalHeaders = new HashMap<>();
         }
-        additionalHeaders.put("Accept", "text/csv");
+        additionalHeaders.put(HttpHeaders.ACCEPT, "text/csv");
         
         return invokeMethodFull(service, method, relativeUrl, body, parameters, additionalHeaders).getBody();
     }
@@ -224,13 +225,13 @@ class SafeguardConnection implements ISafeguardConnection {
         
         Map<String,String> headers = new HashMap<>();
         if (!(authenticationMechanism instanceof AnonymousAuthenticator)) { 
-            headers.put("Authorization", String.format("Bearer %s", new String(authenticationMechanism.getAccessToken())));
+            headers.put(HttpHeaders.AUTHORIZATION, String.format("Bearer %s", new String(authenticationMechanism.getAccessToken())));
         }
         
         if (additionalHeaders != null) { 
             headers.putAll(additionalHeaders);
-            if (!additionalHeaders.containsKey("Accept"))
-                headers.put("Accept", "application/json"); // Assume JSON unless specified
+            if (!additionalHeaders.containsKey(HttpHeaders.ACCEPT))
+                headers.put(HttpHeaders.ACCEPT, "application/json"); // Assume JSON unless specified
         }
         return headers;
     }

--- a/src/main/java/com/oneidentity/safeguard/safeguardjava/authentication/AnonymousAuthenticator.java
+++ b/src/main/java/com/oneidentity/safeguard/safeguardjava/authentication/AnonymousAuthenticator.java
@@ -6,6 +6,7 @@ import com.oneidentity.safeguard.safeguardjava.restclient.RestClient;
 import java.util.HashMap;
 import java.util.Map;
 import javax.net.ssl.HostnameVerifier;
+import org.apache.http.HttpHeaders;
 import org.apache.http.client.methods.CloseableHttpResponse;
 
 public class AnonymousAuthenticator extends AuthenticatorBase {
@@ -19,8 +20,8 @@ public class AnonymousAuthenticator extends AuthenticatorBase {
         RestClient notificationClient = new RestClient(notificationUrl, ignoreSsl, validationCallback);
         
         Map<String,String> headers = new HashMap<>();
-        headers.put("Accept", "application/json");
-        headers.put("Content-type", "application/json");
+        headers.put(HttpHeaders.ACCEPT, "application/json");
+        headers.put(HttpHeaders.CONTENT_TYPE, "application/json");
         CloseableHttpResponse response = notificationClient.execGET("Status", null, headers);
 
         if (response == null) {

--- a/src/main/java/com/oneidentity/safeguard/safeguardjava/authentication/AuthenticatorBase.java
+++ b/src/main/java/com/oneidentity/safeguard/safeguardjava/authentication/AuthenticatorBase.java
@@ -1,25 +1,35 @@
 package com.oneidentity.safeguard.safeguardjava.authentication;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.oneidentity.safeguard.safeguardjava.Utils;
 import com.oneidentity.safeguard.safeguardjava.data.AccessTokenBody;
+import com.oneidentity.safeguard.safeguardjava.data.JsonBody;
 import com.oneidentity.safeguard.safeguardjava.exceptions.ObjectDisposedException;
 import com.oneidentity.safeguard.safeguardjava.exceptions.SafeguardForJavaException;
 import com.oneidentity.safeguard.safeguardjava.restclient.RestClient;
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.net.ssl.HostnameVerifier;
+import org.apache.http.HttpHeaders;
 import org.apache.http.client.methods.CloseableHttpResponse;
 
-abstract class AuthenticatorBase implements IAuthenticationMechanism
-{
+abstract class AuthenticatorBase implements IAuthenticationMechanism {
+
     private boolean disposed;
 
-    private final String networkAddress; 
+    private final String networkAddress;
     private final int apiVersion;
     private final boolean ignoreSsl;
     private final HostnameVerifier validationCallback;
-    
+
     protected char[] accessToken;
 
     protected final String safeguardRstsUrl;
@@ -28,8 +38,7 @@ abstract class AuthenticatorBase implements IAuthenticationMechanism
     protected RestClient rstsClient;
     protected RestClient coreClient;
 
-    protected AuthenticatorBase(String networkAddress, int apiVersion, boolean ignoreSsl, HostnameVerifier validationCallback)
-    {
+    protected AuthenticatorBase(String networkAddress, int apiVersion, boolean ignoreSsl, HostnameVerifier validationCallback) {
         this.networkAddress = networkAddress;
         this.apiVersion = apiVersion;
         this.ignoreSsl = ignoreSsl;
@@ -43,7 +52,7 @@ abstract class AuthenticatorBase implements IAuthenticationMechanism
     }
 
     public abstract String getId();
-    
+
     @Override
     public String getNetworkAddress() {
         return networkAddress;
@@ -58,7 +67,7 @@ abstract class AuthenticatorBase implements IAuthenticationMechanism
     public boolean isIgnoreSsl() {
         return ignoreSsl;
     }
-    
+
     @Override
     public HostnameVerifier getValidationCallback() {
         return validationCallback;
@@ -67,7 +76,7 @@ abstract class AuthenticatorBase implements IAuthenticationMechanism
     public boolean isAnonymous() {
         return false;
     }
-    
+
     @Override
     public boolean hasAccessToken() {
         return accessToken != null;
@@ -75,35 +84,41 @@ abstract class AuthenticatorBase implements IAuthenticationMechanism
 
     @Override
     public void clearAccessToken() {
-        if (accessToken != null)
+        if (accessToken != null) {
             Arrays.fill(accessToken, '0');
+        }
         accessToken = null;
     }
-            
+
     @Override
     public char[] getAccessToken() throws ObjectDisposedException {
-        if (disposed)
+        if (disposed) {
             throw new ObjectDisposedException("AuthenticatorBase");
+        }
         return accessToken;
     }
 
     @Override
     public int getAccessTokenLifetimeRemaining() throws ObjectDisposedException, SafeguardForJavaException {
-        if (disposed)
+        if (disposed) {
             throw new ObjectDisposedException("AuthenticatorBase");
-        if (!hasAccessToken())
+        }
+        if (!hasAccessToken()) {
             return 0;
-        
-        Map<String,String> headers = new HashMap<>();
-        headers.put("Authorization", String.format("Bearer %s", new String(accessToken)));
+        }
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put(HttpHeaders.AUTHORIZATION, String.format("Bearer %s", new String(accessToken)));
         headers.put("X-TokenLifetimeRemaining", "");
-        
+
         CloseableHttpResponse response = coreClient.execGET("LoginMessage", null, headers);
-        
-        if (response == null)
+
+        if (response == null) {
             throw new SafeguardForJavaException(String.format("Unable to connect to web service %s", coreClient.getBaseURL()));
-        if (!Utils.isSuccessful(response.getStatusLine().getStatusCode())) 
+        }
+        if (!Utils.isSuccessful(response.getStatusLine().getStatusCode())) {
             return 0;
+        }
 
         String remainingStr = null;
         if (response.containsHeader("X-TokenLifetimeRemaining")) {
@@ -114,44 +129,111 @@ abstract class AuthenticatorBase implements IAuthenticationMechanism
         if (remainingStr != null) {
             try {
                 remaining = Integer.parseInt(remainingStr);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
             }
         }
-            
+
         return remaining;
     }
 
     @Override
     public void refreshAccessToken() throws ObjectDisposedException, SafeguardForJavaException {
-        
-        if (disposed)
+
+        if (disposed) {
             throw new ObjectDisposedException("AuthenticatorBase");
-        
+        }
+
         char[] rStsToken = getRstsTokenInternal();
         AccessTokenBody body = new AccessTokenBody(rStsToken);
         CloseableHttpResponse response = coreClient.execPOST("Token/LoginResponse", null, null, body);
 
-        if (response == null)
+        if (response == null) {
             throw new SafeguardForJavaException(String.format("Unable to connect to web service %s", coreClient.getBaseURL()));
-        
-        String reply = Utils.getResponse(response);
-        if (!Utils.isSuccessful(response.getStatusLine().getStatusCode())) 
-            throw new SafeguardForJavaException("Error exchanging RSTS token from " + this.getId() + "authenticator for Safeguard API access token, Error: " +
-                                               String.format("%d %s", response.getStatusLine().getStatusCode(), reply));
+        }
 
-        Map<String,String> map = Utils.parseResponse(reply);
-        if (map.containsKey("UserToken"))
-            accessToken =  map.get("UserToken").toCharArray();
+        String reply = Utils.getResponse(response);
+        if (!Utils.isSuccessful(response.getStatusLine().getStatusCode())) {
+            throw new SafeguardForJavaException("Error exchanging RSTS token from " + this.getId() + "authenticator for Safeguard API access token, Error: "
+                    + String.format("%d %s", response.getStatusLine().getStatusCode(), reply));
+        }
+
+        Map<String, String> map = Utils.parseResponse(reply);
+        if (map.containsKey("UserToken")) {
+            accessToken = map.get("UserToken").toCharArray();
+        }
+    }
+    
+    public String resolveProviderToScope(String provider) throws SafeguardForJavaException
+    {
+        try
+        {
+            CloseableHttpResponse response;
+            Map<String,String> headers = new HashMap<>();
+            Map<String,String> parameters = new HashMap<>();
+            
+            headers.clear();
+            parameters.clear();
+
+            headers.put(HttpHeaders.ACCEPT, "application/json");
+            headers.put(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded");
+            parameters.put("response_type", "token");
+            parameters.put("redirect_uri", "urn:InstalledApplication");
+            parameters.put("loginRequestStep", "1");
+
+            response = rstsClient.execPOST("UserLogin/LoginController", parameters, headers, new JsonBody("RelayState="));
+                
+            if (response == null || (!Utils.isSuccessful(response.getStatusLine().getStatusCode())))
+                response = rstsClient.execGET("UserLogin/LoginController", parameters, headers);
+            
+            if (response == null)
+                throw new SafeguardForJavaException("Unable to connect to RSTS to find identity provider scopes");
+            
+            String reply = Utils.getResponse(response);
+            if (!Utils.isSuccessful(response.getStatusLine().getStatusCode())) 
+                throw new SafeguardForJavaException("Error requesting identity provider scopes from RSTS, Error: " +
+                        String.format("%d %s", response.getStatusLine().getStatusCode(), reply));
+            
+            List<Provider> knownScopes = parseLoginResponse(reply);
+
+            // 3 step check for determining if the user provided scope is valid:
+            //
+            // 1. User value == RSTSProviderId
+            // 2. User value == Identity Provider Display Name.
+            //    - This allows the caller to specify the domain name for AD.
+            // 3. User Value is contained in RSTSProviderId.
+            //    - This allows the caller to specify the provider Id rather than the full RSTSProviderId.
+            //    - Such a broad check could provide some issues with false matching, however since this
+            //      was in the original code, this check has been left in place.
+            Provider scope = getMatchingScope(provider, knownScopes);
+
+            if (scope == null)
+            {
+                StringBuilder s = new StringBuilder();
+                knownScopes.forEach((p) -> {
+                    if (s.length() > 0)
+                        s.append(", ");
+                    s.append(p.DisplayName + ", " + p.Id);
+                });
+                throw new SafeguardForJavaException(String.format("Unable to find scope matching '%s' in [%s]", provider, s.toString()));
+            }
+            
+            return String.format("rsts:sts:primaryproviderid:%s", scope.Id);
+        }
+        catch (SafeguardForJavaException ex) {
+            throw ex;
+        }
+        catch (Exception ex)
+        {
+            throw new SafeguardForJavaException("Unable to connect to determine identity provider", ex);
+        }
     }
 
     protected abstract char[] getRstsTokenInternal() throws ObjectDisposedException, SafeguardForJavaException;
-    
+
     public abstract Object cloneObject() throws SafeguardForJavaException;
-    
+
     @Override
-    public void dispose()
-    {
+    public void dispose() {
         clearAccessToken();
         disposed = true;
     }
@@ -159,13 +241,68 @@ abstract class AuthenticatorBase implements IAuthenticationMechanism
     @Override
     protected void finalize() throws Throwable {
         try {
-            
-            if (accessToken != null)
+
+            if (accessToken != null) {
                 Arrays.fill(accessToken, '0');
+            }
         } finally {
             disposed = true;
             super.finalize();
         }
     }
     
+    private class Provider {
+        private String Id;
+        private String DisplayName;
+
+        public Provider(String Id, String DisplayName) {
+            this.Id = Id;
+            this.DisplayName = DisplayName;
+        }
+
+        public String getId() {
+            return Id;
+        }
+
+        public String getDisplayName() {
+            return DisplayName;
+        }
+    }
+    private List<Provider> parseLoginResponse(String response) {
+        
+        List<Provider> providers = new ArrayList<>();
+        ObjectMapper mapper = new ObjectMapper();
+        
+        try {
+            JsonNode jsonNodeRoot = mapper.readTree(response);
+            JsonNode jsonNodeProviders = jsonNodeRoot.get("Providers");
+            Iterator<JsonNode> iter = jsonNodeProviders.elements();
+            
+            while(iter.hasNext()){
+		JsonNode providerNode=iter.next();
+                Provider p = new Provider(getJsonValue(providerNode, "Id"), getJsonValue(providerNode, "DisplayName"));
+		providers.add(p);
+            }            
+        } catch (IOException ex) {
+            Logger.getLogger(Utils.class.getName()).log(Level.SEVERE, null, ex);
+        }
+
+        return providers;
+    }
+    
+    private Provider getMatchingScope(String provider, List<Provider> providers) {
+        for (Provider s : providers) {
+            if (s.DisplayName.equalsIgnoreCase(provider) || s.Id.equalsIgnoreCase(provider))
+                return s;
+        }
+        return null;
+    }
+    
+    private String getJsonValue(JsonNode node, String propName) {
+        if (node.get(propName) != null) {
+            return node.get(propName).asText();
+        }
+        return null;
+    }
+
 }

--- a/src/main/java/com/oneidentity/safeguard/safeguardjava/authentication/IAuthenticationMechanism.java
+++ b/src/main/java/com/oneidentity/safeguard/safeguardjava/authentication/IAuthenticationMechanism.java
@@ -18,6 +18,7 @@ public interface IAuthenticationMechanism
     int getAccessTokenLifetimeRemaining() throws ObjectDisposedException, SafeguardForJavaException;
     HostnameVerifier getValidationCallback();
     void refreshAccessToken() throws ObjectDisposedException, SafeguardForJavaException;
+    String resolveProviderToScope(String provider) throws SafeguardForJavaException;
     Object cloneObject() throws SafeguardForJavaException;
     void dispose();
 }

--- a/src/main/java/com/oneidentity/safeguard/safeguardjava/authentication/PasswordAuthenticator.java
+++ b/src/main/java/com/oneidentity/safeguard/safeguardjava/authentication/PasswordAuthenticator.java
@@ -1,19 +1,11 @@
 package com.oneidentity.safeguard.safeguardjava.authentication;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.oneidentity.safeguard.safeguardjava.Utils;
-import com.oneidentity.safeguard.safeguardjava.data.JsonBody;
 import com.oneidentity.safeguard.safeguardjava.data.OauthBody;
 import com.oneidentity.safeguard.safeguardjava.exceptions.ArgumentException;
 import com.oneidentity.safeguard.safeguardjava.exceptions.ObjectDisposedException;
 import com.oneidentity.safeguard.safeguardjava.exceptions.SafeguardForJavaException;
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -50,65 +42,13 @@ public class PasswordAuthenticator extends AuthenticatorBase
         return "Password";
     }
 
-    private void resolveProviderToScope() throws SafeguardForJavaException
-    {
-        try
-        {
-            CloseableHttpResponse response;
-            Map<String,String> headers = new HashMap<>();
-            Map<String,String> parameters = new HashMap<>();
-            
-            headers.clear();
-            parameters.clear();
-
-            headers.put("Content-type", "application/x-www-form-urlencoded");
-            parameters.put("response_type", "token");
-            parameters.put("redirect_uri", "urn:InstalledApplication");
-            parameters.put("loginRequestStep", "1");
-
-            response = rstsClient.execPOST("UserLogin/LoginController", parameters, headers, new JsonBody("RelayState="));
-                
-            if (response == null || (!Utils.isSuccessful(response.getStatusLine().getStatusCode())))
-                response = rstsClient.execGET("UserLogin/LoginController", parameters, headers);
-            
-            if (response == null)
-                throw new SafeguardForJavaException("Unable to connect to RSTS to find identity provider scopes");
-            
-            String reply = Utils.getResponse(response);
-            if (!Utils.isSuccessful(response.getStatusLine().getStatusCode())) 
-                throw new SafeguardForJavaException("Error requesting identity provider scopes from RSTS, Error: " +
-                        String.format("%d %s", response.getStatusLine().getStatusCode(), reply));
-
-            List<String> knownScopes = parseLoginResponse(reply);
-            String scope = getMatchingScope(knownScopes, true);
-
-            if (scope != null)
-                providerScope = String.format("rsts:sts:primaryproviderid:%s", scope);
-            else
-            {
-                scope = getMatchingScope(knownScopes, false);
-                if (providerScope != null)
-                    providerScope = String.format("rsts:sts:primaryproviderid:%s", scope);
-                else
-                    throw new SafeguardForJavaException(String.format("Unable to find scope matching '%s' in [%s]", provider, String.join(",", knownScopes)));
-            }
-        }
-        catch (SafeguardForJavaException ex) {
-            throw ex;
-        }
-        catch (Exception ex)
-        {
-            throw new SafeguardForJavaException("Unable to connect to determine identity provider", ex);
-        }
-    }
-
     @Override
     protected char[] getRstsTokenInternal() throws ObjectDisposedException, SafeguardForJavaException
     {
         if (disposed)
             throw new ObjectDisposedException("PasswordAuthenticator");
         if (providerScope == null)
-            resolveProviderToScope();
+            providerScope = resolveProviderToScope(provider);
 
         OauthBody body = new OauthBody("password", username, password, providerScope);
         CloseableHttpResponse response = rstsClient.execPOST("oauth2/token", null, null, body);
@@ -163,44 +103,4 @@ public class PasswordAuthenticator extends AuthenticatorBase
         }
     }
     
-    private List<String> parseLoginResponse(String response) {
-        
-        List<String> providers = new ArrayList<>();
-        ObjectMapper mapper = new ObjectMapper();
-        
-        try {
-            JsonNode jsonNodeRoot = mapper.readTree(response);
-            JsonNode jsonNodeProviders = jsonNodeRoot.get("Providers");
-            Iterator<JsonNode> iter = jsonNodeProviders.elements();
-            
-            while(iter.hasNext()){
-		JsonNode providerNode=iter.next();
-		providers.add(getJsonValue(providerNode, "Id"));
-            }            
-        } catch (IOException ex) {
-            Logger.getLogger(Utils.class.getName()).log(Level.SEVERE, null, ex);
-        }
-
-        return providers;
-    }
-    
-    private String getMatchingScope(List<String> providers, boolean equals) {
-        for (String s : providers) {
-            if (equals) {
-                if (s.equalsIgnoreCase(provider))
-                    return s;
-            } else {
-                if (s.toLowerCase().contains(provider.toLowerCase()))
-                    return s;
-            }
-        }
-        return null;
-    }
-    
-    private String getJsonValue(JsonNode node, String propName) {
-        if (node.get(propName) != null) {
-            return node.get(propName).asText();
-        }
-        return null;
-    }
 }

--- a/src/main/java/com/oneidentity/safeguard/safeguardjava/data/KeyFormat.java
+++ b/src/main/java/com/oneidentity/safeguard/safeguardjava/data/KeyFormat.java
@@ -1,0 +1,20 @@
+package com.oneidentity.safeguard.safeguardjava.data;
+
+/**
+ *  A list of private key formats supported by Safeguard.
+ */
+public enum KeyFormat
+{
+    /**
+     *  OpenSSH legacy PEM format
+     */
+    OpenSsh,
+    /**
+     *  Tectia format for use with tools from SSH.com
+    */
+    Ssh2,
+    /**
+     *  PuttY format for use with PuTTY tools
+    */
+    Putty
+}

--- a/src/main/java/com/oneidentity/safeguard/safeguardjava/event/PersistentSafeguardA2AEventListener.java
+++ b/src/main/java/com/oneidentity/safeguard/safeguardjava/event/PersistentSafeguardA2AEventListener.java
@@ -34,6 +34,7 @@ public class PersistentSafeguardA2AEventListener extends PersistentSafeguardEven
         this.apiKey = apiKey.clone();
         this.apiKeys = null;
         registerEventHandler("AssetAccountPasswordUpdated", handler);
+        registerEventHandler("AssetAccountSshKeyUpdated", handler);
         Logger.getLogger(PersistentSafeguardA2AEventListener.class.getName()).log(Level.FINEST, "Persistent A2A event listener successfully created.");
     }
 
@@ -52,6 +53,7 @@ public class PersistentSafeguardA2AEventListener extends PersistentSafeguardEven
             throw new ArgumentException("Parameter apiKeys must include at least one item");
         }
         registerEventHandler("AssetAccountPasswordUpdated", handler);
+        registerEventHandler("AssetAccountSshKeyUpdated", handler);
         Logger.getLogger(PersistentSafeguardA2AEventListener.class.getName()).log(Level.FINEST, "Persistent A2A event listener successfully created.");
     }
     

--- a/src/main/java/microsoft/aspnet/signalr/client/transport/HttpClientTransport.java
+++ b/src/main/java/microsoft/aspnet/signalr/client/transport/HttpClientTransport.java
@@ -21,6 +21,7 @@ import microsoft.aspnet.signalr.client.http.HttpConnectionFuture.ResponseCallbac
 import microsoft.aspnet.signalr.client.http.InvalidHttpStatusCodeException;
 import microsoft.aspnet.signalr.client.http.Request;
 import microsoft.aspnet.signalr.client.http.Response;
+import org.apache.http.HttpHeaders;
 
 /**
  * ClientTransport base implementation over Http
@@ -120,7 +121,7 @@ public abstract class HttpClientTransport implements ClientTransport {
             post.setFormContent("data", data);
             post.setUrl(connection.getUrl() + "send" + TransportHelper.getSendQueryString(this, connection));
             post.setHeaders(connection.getHeaders());
-            post.addHeader("Content-Type", "application/x-www-form-urlencoded");
+            post.addHeader(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded");
 
             connection.prepareRequest(post);
 


### PR DESCRIPTION
Add the ability to specify a provider, ability to release A2A private keys, other minor bug fixes.