### PR TITLE
Implement the callback for the SignalR connection state. 

### DIFF
--- a/src/main/java/com/oneidentity/safeguard/safeguardjava/Safeguard.java
+++ b/src/main/java/com/oneidentity/safeguard/safeguardjava/Safeguard.java
@@ -1887,6 +1887,8 @@ public final class Safeguard {
             }
             
             /**
+             *  NOT SUPPORTED
+             * 
              *  Get a persistent A2A event listener. The handler passed in 
              *  will be registered for the AssetAccountPasswordUpdated event, 
              *  which is the only one supported in A2A. Uses a client 
@@ -1913,6 +1915,9 @@ public final class Safeguard {
                     HostnameVerifier validationCallback, Integer apiVersion)
                     throws ObjectDisposedException, ArgumentException, SafeguardForJavaException {
                 
+                throw new SafeguardForJavaException("Not supported. This function is not available for Java.");
+                    
+                /*
                 int version = DEFAULTAPIVERSION;
                 if (apiVersion != null) {
                     version = apiVersion;
@@ -1930,9 +1935,12 @@ public final class Safeguard {
                 return new PersistentSafeguardA2AEventListener(
                         new SafeguardA2AContext(networkAddress, version, false, 
                                 thumbprint, validationCallback), apiKeys, handler);
+                */
             }
             
             /**
+             *  NOT SUPPORTED
+             * 
              *  Get a persistent A2A event listener. The handler passed in 
              *  will be registered for the AssetAccountPasswordUpdated event, 
              *  which is the only one supported in A2A. Uses a client 
@@ -1959,6 +1967,9 @@ public final class Safeguard {
                     Integer apiVersion, Boolean ignoreSsl)
                     throws ObjectDisposedException, ArgumentException, SafeguardForJavaException {
                 
+                throw new SafeguardForJavaException("Not supported. This function is not available for Java.");
+                
+                /*
                 int version = DEFAULTAPIVERSION;
                 if (apiVersion != null) {
                     version = apiVersion;
@@ -1981,6 +1992,7 @@ public final class Safeguard {
                 return new PersistentSafeguardA2AEventListener(
                         new SafeguardA2AContext(networkAddress, version, ignoreSsl, 
                                 thumbprint, null), apiKeys, handler);
+                */
             }
             
             /**

--- a/src/main/java/com/oneidentity/safeguard/safeguardjava/data/SafeguardEventListenerState.java
+++ b/src/main/java/com/oneidentity/safeguard/safeguardjava/data/SafeguardEventListenerState.java
@@ -1,0 +1,16 @@
+package com.oneidentity.safeguard.safeguardjava.data;
+
+    /** <summary>
+     * Connection state of the Safeguard event listener.
+     */ 
+    public enum SafeguardEventListenerState
+    {
+        /**
+         * Event listener connected.
+         */
+        Connected,
+        /**
+         * Event listener disconnected.
+         */
+        Disconnected
+    }

--- a/src/main/java/com/oneidentity/safeguard/safeguardjava/event/ISafeguardEventListener.java
+++ b/src/main/java/com/oneidentity/safeguard/safeguardjava/event/ISafeguardEventListener.java
@@ -23,6 +23,14 @@ public interface ISafeguardEventListener
     void registerEventHandler(String eventName, ISafeguardEventHandler handler) throws ObjectDisposedException;
 
     /**
+     * Set an event listener callback that will be called each time the connection
+     * state changes of the event listener.
+     *
+     * @param eventListenerStateCallback Callback method.
+     */ 
+    void SetEventListenerStateCallback(ISafeguardEventListenerStateCallback eventListenerStateCallback);
+        
+    /**
      * Start listening for Safeguard events in a background thread.
      * @throws ObjectDisposedException Object has already been disposed
      * @throws SafeguardForJavaException General Safeguard for Java exception

--- a/src/main/java/com/oneidentity/safeguard/safeguardjava/event/ISafeguardEventListenerStateCallback.java
+++ b/src/main/java/com/oneidentity/safeguard/safeguardjava/event/ISafeguardEventListenerStateCallback.java
@@ -1,0 +1,16 @@
+package com.oneidentity.safeguard.safeguardjava.event;
+
+import com.oneidentity.safeguard.safeguardjava.data.SafeguardEventListenerState;
+
+/**
+ * A callback that will be called whenever the event listener connection state Changes.
+ */ 
+public interface ISafeguardEventListenerStateCallback {
+    /**
+     * Handles an incoming event listener connection change.
+     * 
+     * @param eventListenerState New connection state of the event listener.
+     */
+    void onEventListenerStateChange(SafeguardEventListenerState eventListenerState);
+}
+

--- a/tests/safeguardjavaclient/src/main/java/com/oneidentity/safeguard/safeguardclient/SafeguardJavaClient.java
+++ b/tests/safeguardjavaclient/src/main/java/com/oneidentity/safeguard/safeguardclient/SafeguardJavaClient.java
@@ -23,6 +23,7 @@ public class SafeguardJavaClient {
         ISafeguardSessionsConnection sessionConnection = null;
         ISafeguardA2AContext a2aContext = null;
         ISafeguardEventListener eventListener = null;
+        ISafeguardEventListener a2aEventListener = null;
         
         boolean done = false;
         SafeguardTests tests = new SafeguardTests();
@@ -97,39 +98,55 @@ public class SafeguardJavaClient {
                         tests.safeguardTestEventListener(eventListener);
                         break;
                     case 19:
-                        eventListener = tests.safeguardDisconnectEventListener(eventListener);
+                        a2aEventListener = tests.safeguardA2AEventListenerByCertificate();
                         break;
                     case 20:
-                        tests.safeguardListBackups(connection);
+                        a2aEventListener = tests.safeguardA2AEventListenerByThumbprint();
                         break;
                     case 21:
-                        tests.safeguardTestBackupDownload(connection);
+                        tests.safeguardTestA2AEventListener(a2aEventListener);
                         break;
                     case 22:
-                        tests.safeguardTestBackupUpload(connection);
+                        {
+                            if (eventListener != null) {
+                                eventListener = tests.safeguardDisconnectEventListener(eventListener);
+                            }
+                            if (a2aEventListener != null) {
+                                a2aEventListener = tests.safeguardDisconnectEventListener(a2aEventListener);
+                            }
+                        }
                         break;
                     case 23:
-                        sessionConnection = tests.safeguardSessionsConnection();
+                        tests.safeguardListBackups(connection);
                         break;
                     case 24:
-                        tests.safeguardSessionsApi(sessionConnection);
+                        tests.safeguardTestBackupDownload(connection);
                         break;
                     case 25:
-                        tests.safeguardSessionsFileUpload(sessionConnection);
+                        tests.safeguardTestBackupUpload(connection);
                         break;
                     case 26:
-                        tests.safeguardSessionsStreamUpload(sessionConnection);
+                        sessionConnection = tests.safeguardSessionsConnection();
                         break;
                     case 27:
-                        tests.safeguardSessionTestRecordingDownload(sessionConnection);
+                        tests.safeguardSessionsApi(sessionConnection);
                         break;
                     case 28:
-                        tests.safeguardTestJoinSps(connection, sessionConnection);
+                        tests.safeguardSessionsFileUpload(sessionConnection);
                         break;
                     case 29:
-                        tests.safeguardTestManagementConnection(connection);
+                        tests.safeguardSessionsStreamUpload(sessionConnection);
                         break;
                     case 30:
+                        tests.safeguardSessionTestRecordingDownload(sessionConnection);
+                        break;
+                    case 31:
+                        tests.safeguardTestJoinSps(connection, sessionConnection);
+                        break;
+                    case 32:
+                        tests.safeguardTestManagementConnection(connection);
+                        break;
+                    case 33:
                         tests.safeguardTestAnonymousConnection(connection);
                         break;
                     default:
@@ -168,18 +185,21 @@ public class SafeguardJavaClient {
         System.out.println ("\t16. Event Listener by keystore");
         System.out.println ("\t17. Event Listener by thumbprint");
         System.out.println ("\t18. Test Event Listener");
-        System.out.println ("\t19. Disconnect Event Listener");
-        System.out.println ("\t20. Test List Backups");
-        System.out.println ("\t21. Test Download Backup File");
-        System.out.println ("\t22. Test Upload Backup File");
-        System.out.println ("\t23. Test SPS Connection");
-        System.out.println ("\t24. Test SPS API");
-        System.out.println ("\t25. Test SPS Firmware Upload");
-        System.out.println ("\t26. Test Stream Upload");
-        System.out.println ("\t27. Test Session Recording Download");
-        System.out.println ("\t28. Test Join SPS");
-        System.out.println ("\t29. Test Management Interface API");
-        System.out.println ("\t30. Test Anonymous Connection");
+        System.out.println ("\t19. A2A Event Listener by certificate file");
+        System.out.println ("\t20. A2A Event Listener by thumbprint");
+        System.out.println ("\t21. Test A2A Event Listener");
+        System.out.println ("\t22. Disconnect Event Listener");
+        System.out.println ("\t23. Test List Backups");
+        System.out.println ("\t24. Test Download Backup File");
+        System.out.println ("\t25. Test Upload Backup File");
+        System.out.println ("\t26. Test SPS Connection");
+        System.out.println ("\t27. Test SPS API");
+        System.out.println ("\t28. Test SPS Firmware Upload");
+        System.out.println ("\t29. Test Stream Upload");
+        System.out.println ("\t30. Test Session Recording Download");
+        System.out.println ("\t31. Test Join SPS");
+        System.out.println ("\t32. Test Management Interface API");
+        System.out.println ("\t33. Test Anonymous Connection");
         
         System.out.println ("\t99. Exit");
         


### PR DESCRIPTION
Implement the callback for the SignalR connection state. Fix some bugs around connecting to the A2A signalr service and mark the A2A Persist event listener APIs that take a thumbprint as not supported. Connecting and authenticating to the A2A signalr service is handled differently than signalr on the core service.  The core service authenticates using an access token via restsharp which is able to use the windows certificate store. It then uses Okhttp with the access token to connect to the signalr service. Connecting to the A2A signalr service is done entirely using okhttp and passing a certificate. Okhttp can't pull a certificate out of the windows certificate store by thumbprint.  The problem is difference in the authentication methods when using Okhttp.