### PR TITLE
chore: add .worktrees to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ hs_err_pid*
 
 # Copilot instructions (keep local only)
 .github/copilot-instructions.md
+
+# Worktrees
+.worktrees/


### PR DESCRIPTION
Add `.worktrees/` directory to `.gitignore` to support git worktree-based development workflows.

This prevents worktree directories from being accidentally committed to the repository.