### PR TITLE
Fix GitHub Release title to use ReleaseTag

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -130,7 +130,7 @@ jobs:
       target: '$(Build.SourceVersion)'
       tagSource: 'userSpecifiedTag'
       tag: '$(ReleaseTag)'
-      title: '$(version)'
+      title: '$(ReleaseTag)'
       isPreRelease: $(isPrerelease)
       changeLogCompareToRelease: 'lastFullRelease'
       changeLogType: 'commitBased'


### PR DESCRIPTION
One-line fix: change GitHub Release title from `\` to `\` for consistency with all other Safeguard repos.