### PR TITLE
Skills harmonization: rename ci-cd-pipeline, add api-patterns and a2a-workflow

### DIFF
--- a/.agents/skills/a2a-workflow/SKILL.md
+++ b/.agents/skills/a2a-workflow/SKILL.md
@@ -1,0 +1,269 @@
+---
+name: a2a-workflow
+description: Use when working with SafeguardJava application-to-application credential retrieval, brokering, or A2A events.
+---
+
+# A2A Workflow
+
+Safeguard Application-to-Application (A2A) is the SDK path for non-interactive
+automation that needs privileged credentials without a user login prompt. In
+SafeguardJava, A2A is certificate-authenticated, API-key-scoped, and exposed
+through `Safeguard.A2A.getContext(...)` plus `ISafeguardA2AContext`. Use it for
+service accounts, scheduled jobs, brokers, and other integrations that need to
+retrieve or rotate credentials directly from Safeguard.
+
+## 1. What A2A is
+
+The main A2A surface is `com.oneidentity.safeguard.safeguardjava.ISafeguardA2AContext`.
+`SafeguardA2AContext` maintains two internal REST clients:
+
+- an A2A client rooted at `https://<appliance>/service/a2a/v<apiVersion>`
+- a core client rooted at `https://<appliance>/service/core/v<apiVersion>`
+
+The A2A client is used for credential retrieval and brokering (`Credentials`,
+`AccessRequests`), while the core client is used to enumerate `A2ARegistrations`
+and their `RetrievableAccounts`.
+
+Important design constraints from the SDK:
+
+- A2A uses certificate auth plus an `Authorization: A2A <apiKey>` header
+- `Service.A2A` is **not** valid with `ISafeguardConnection`
+- API keys are stored as `char[]` in the public interfaces
+- context objects must be cleaned up with `dispose()`
+
+## 2. Setup flow (certificate registration, API key creation)
+
+The repository samples document the expected appliance-side setup:
+
+1. **Trust the certificate chain**
+   - `Samples/CertificateConnect/README.md` calls out uploading the root/intermediate CA chain
+   - the certificate must be trusted by Safeguard before certificate auth or A2A will work
+2. **Register the application / certificate identity**
+   - create the application user or mapping that represents the calling service
+   - certificate identity can come from a file, keystore alias, in-memory bytes, or a Windows thumbprint
+3. **Create A2A registrations**
+   - `Samples/A2ARetrievalExample/README.md` calls out configuring retrieval registrations
+   - each retrievable credential gets an API key that scopes access to that item
+4. **Distribute the client certificate and API key securely**
+   - keep certificate passwords, API keys, and retrieved secrets in `char[]`
+   - never check PFX/JKS files, passwords, or API keys into the repo
+
+### Choosing a `getContext(...)` overload
+
+`Safeguard.A2A.getContext(...)` supports the same certificate sources the rest of the SDK uses:
+
+- keystore path + alias
+- PKCS12 / PFX file path
+- in-memory certificate bytes
+- Windows certificate thumbprint (Windows only)
+- optional `apiVersion`
+- either `ignoreSsl` or a custom `HostnameVerifier`
+
+Examples from the actual factories in `Safeguard.java`:
+
+```java
+ISafeguardA2AContext fromFile = Safeguard.A2A.getContext(
+        appliance,
+        certificatePath,
+        certificatePassword,
+        null,
+        true);
+
+ISafeguardA2AContext fromKeystore = Safeguard.A2A.getContext(
+        appliance,
+        keystorePath,
+        keystorePassword,
+        certificateAlias,
+        null,
+        true);
+```
+
+Windows thumbprint overloads require `SunMSCAPI` to be available. The SDK throws a
+`SafeguardForJavaException` on non-Windows platforms or when the provider is missing.
+
+## 3. Credential retrieval (programmatic access)
+
+### Enumerate retrievable accounts
+
+`ISafeguardA2AContext.getRetrievableAccounts()` first queries `Core/A2ARegistrations`,
+then enumerates each registration's `RetrievableAccounts` endpoint. The returned
+`IA2ARetrievableAccount` objects include application name, asset/account details,
+and the API key as `char[]`.
+
+```java
+List<IA2ARetrievableAccount> accounts = a2aContext.getRetrievableAccounts();
+for (IA2ARetrievableAccount account : accounts) {
+    System.out.println(account.getAssetName() + " -> " + account.getAccountName());
+}
+```
+
+There is also a filtered form:
+
+```java
+List<IA2ARetrievableAccount> accounts =
+        a2aContext.getRetrievableAccounts("AccountName eq 'admin'");
+```
+
+The filter is passed server-side as the `filter` query parameter on each registration lookup.
+
+### Retrieve a password
+
+This is the path shown in `Samples/A2ARetrievalExample/.../A2ARetrievalExample.java`:
+
+```java
+char[] password = a2aContext.retrievePassword(apiKey);
+try {
+    usePassword(password);
+} finally {
+    java.util.Arrays.fill(password, '\0');
+}
+```
+
+Internally, the SDK sends:
+
+- `GET Credentials`
+- query parameter `type=Password`
+- header `Authorization: A2A <apiKey>`
+- client certificate on the TLS connection
+
+### Set a password
+
+The setter method name is capitalized in this SDK:
+
+```java
+a2aContext.SetPassword(apiKey, newPassword);
+```
+
+That becomes `PUT Credentials/Password` with a JSON string body.
+
+### Retrieve or set an SSH private key
+
+```java
+char[] privateKey = a2aContext.retrievePrivateKey(apiKey, KeyFormat.OpenSsh);
+a2aContext.SetPrivateKey(apiKey, privateKey, passphrase, KeyFormat.OpenSsh);
+```
+
+The getter uses `GET Credentials?type=PrivateKey&keyFormat=<format>`.
+The setter uses `PUT Credentials/SshKey` with a serialized `SshKey` payload.
+
+### Retrieve API key secrets
+
+```java
+List<IApiKeySecret> secrets = a2aContext.retrieveApiKeySecret(apiKey);
+```
+
+This uses `GET Credentials?type=ApiKey` and maps the response into `ApiKeySecret`
+objects with `clientId`, `clientSecret`, and related metadata.
+
+## 4. Brokering
+
+SafeguardJava supports brokering through:
+
+- `IBrokeredAccessRequest`
+- `BrokeredAccessRequest`
+- `BrokeredAccessRequestType`
+- `ISafeguardA2AContext.brokerAccessRequest(...)`
+
+The test harness in `tests/safeguardjavaclient/.../SafeguardTests.java` builds a
+`BrokeredAccessRequest`, sets `AccountId`, `AssetId`, `ForUserId`, and an access type,
+then calls `brokerAccessRequest(...)`.
+
+Minimal pattern:
+
+```java
+IBrokeredAccessRequest request = new BrokeredAccessRequest();
+request.setForUserId(forUserId);
+request.setAssetId(assetId);
+request.setAccountId(accountId);
+request.setAccessType(BrokeredAccessRequestType.Password);
+request.setReasonComment("Created by service broker");
+
+String result = a2aContext.brokerAccessRequest(apiKey, request);
+```
+
+What the SDK enforces before sending `POST AccessRequests`:
+
+- either `ForUserId` or `ForUserName` must be set
+- either `AssetId` or `AssetName` must be set
+- `apiKey` and `accessRequest` cannot be null
+- the SDK stamps the request version from the active `apiVersion`
+
+`BrokeredAccessRequest` also exposes optional fields for emergency access, reason
+codes, ticket numbers, `RequestedFor`, and day/hour/minute duration values.
+
+## 5. Event listeners / SignalR
+
+A2A supports SignalR listeners through the same `ISafeguardEventListener` interface used
+for standard Safeguard events.
+
+### Context-based listeners
+
+From `ISafeguardA2AContext`:
+
+- `getA2AEventListener(char[] apiKey, ISafeguardEventHandler handler)`
+- `getA2AEventListener(List<char[]> apiKeys, ISafeguardEventHandler handler)`
+- `getPersistentA2AEventListener(char[] apiKey, ISafeguardEventHandler handler)`
+- `getPersistentA2AEventListener(List<char[]> apiKeys, ISafeguardEventHandler handler)`
+
+`SafeguardA2AContext` automatically registers these event names on the listener:
+
+- `AssetAccountPasswordUpdated`
+- `AssetAccountSshKeyUpdated`
+- `AccountApiKeySecretUpdated`
+
+Basic usage:
+
+```java
+ISafeguardEventHandler handler = (eventName, eventBody) -> {
+    System.out.println(eventName);
+    System.out.println(eventBody);
+};
+
+ISafeguardEventListener listener =
+        a2aContext.getPersistentA2AEventListener(apiKey, handler);
+listener.start();
+```
+
+### Factory-based listeners
+
+If you do not want to build the context yourself, `Safeguard.A2A.Event` exposes many
+`getPersistentA2AEventListener(...)` overloads that accept certificate file, keystore,
+thumbprint, or in-memory certificate inputs directly.
+
+### Reconnect behavior
+
+`PersistentSafeguardA2AEventListener` extends `PersistentSafeguardEventListenerBase`.
+When the internal SignalR listener disconnects, the base class:
+
+1. disposes the broken listener
+2. recreates it from the A2A context
+3. re-registers handlers
+4. sleeps 5 seconds between failed reconnect attempts
+
+This is the right choice for long-running services.
+
+Non-persistent listeners do **not** recover from long outages.
+The interface documentation calls out the 30+ second outage case explicitly.
+
+## 6. Error scenarios and troubleshooting
+
+Common failures are visible directly in the public methods:
+
+- `ObjectDisposedException` if you call the context after `dispose()`
+- `ArgumentException` for null `apiKey`, null password/private-key arguments, or an empty API key list
+- `SafeguardForJavaException("Unable to connect to web service ...")` when the HTTP client returns null
+- `SafeguardForJavaException("Error returned from Safeguard API, Error: <status> <body>")` for non-2xx responses
+- `SafeguardForJavaException("You must specify a user...")` or `("You must specify an asset...")` during brokering
+- `SafeguardForJavaException("Error parsing JSON response")` or serialization failures when payload conversion breaks
+- `SafeguardForJavaException("Missing SunMSCAPI provider...")` for Windows thumbprint usage without the provider
+- `SafeguardForJavaException("Not implemented. This function is only available on the Windows platform.")` for thumbprint overloads on non-Windows hosts
+
+Troubleshooting checklist:
+
+1. verify the certificate chain is trusted by Safeguard
+2. confirm the certificate maps to the intended application identity
+3. confirm the API key belongs to the registration you expect
+4. use `getRetrievableAccounts()` to prove what the certificate can actually see
+5. switch from a transient listener to a persistent listener if outages matter
+6. avoid `ignoreSsl=true` outside lab scenarios
+7. clear API keys, passwords, and retrieved secrets from memory when finished

--- a/.agents/skills/api-patterns/SKILL.md
+++ b/.agents/skills/api-patterns/SKILL.md
@@ -1,0 +1,281 @@
+---
+name: api-patterns
+description: Use when making standard Safeguard REST API calls through SafeguardJava connections.
+---
+
+# API Patterns
+
+Use this skill when you need to translate a Safeguard REST endpoint into the Java SDK's
+`ISafeguardConnection` calling pattern. The core workflow is always the same: create an
+`ISafeguardConnection` with `Safeguard.connect(...)`, choose a `Service` and `Method`,
+pass a service-relative URL, then decide whether you need just the body
+(`invokeMethod`), a full status/header/body wrapper (`invokeMethodFull`), or CSV output
+(`invokeMethodCsv`).
+
+## 1. Service / endpoint enumeration
+
+SafeguardJava routes standard API calls through `com.oneidentity.safeguard.safeguardjava.data.Service`:
+
+| `Service` value | Base path built by `SafeguardConnection` | Typical use |
+|---|---|---|
+| `Service.Core` | `https://<appliance>/service/core/v<apiVersion>` | Most day-to-day REST work: users, assets, settings, requests |
+| `Service.Appliance` | `https://<appliance>/service/appliance/v<apiVersion>` | Appliance-local operations such as backups and network interfaces |
+| `Service.Notification` | `https://<appliance>/service/notification/v<apiVersion>` | Anonymous/read-only status-style endpoints |
+| `Service.Management` | `https://<address>/service/management/v<apiVersion>` | Management-service-only calls via `GetManagementServiceConnection(...)` |
+| `Service.A2A` | not supported through `ISafeguardConnection` | Use `Safeguard.A2A.getContext(...)` instead |
+
+HTTP verbs are limited to `com.oneidentity.safeguard.safeguardjava.data.Method`:
+
+- `Method.Get`
+- `Method.Post`
+- `Method.Put`
+- `Method.Delete`
+
+There is no generic `PATCH` helper in `ISafeguardConnection`.
+
+The SDK default API version is `4` (defined in `Safeguard.java`). Most `connect(...)`
+and `getContext(...)` overloads accept `apiVersion` if you need to target an older API.
+
+## 2. URL construction and method dispatch
+
+`SafeguardConnection` builds the service root for you. Pass only the service-relative
+path, not the full URL.
+
+```java
+String me = connection.invokeMethod(
+        Service.Core,
+        Method.Get,
+        "Me",
+        null,
+        null,
+        null,
+        null);
+```
+
+Internally, `SafeguardConnection.invokeMethodFull(...)`:
+
+1. validates that `relativeUrl` is not null or empty
+2. picks the right `RestClient` from `getClientForService(...)`
+3. adds `Authorization: Bearer <token>` unless the connection is anonymous
+4. dispatches to `execGET`, `execPOST`, `execPUT`, or `execDELETE`
+5. wraps the result in `FullResponse`
+6. throws `SafeguardForJavaException` on non-success responses
+
+### Query parameters, headers, and timeout
+
+The full signature is:
+
+```java
+String invokeMethod(
+        Service service,
+        Method method,
+        String relativeUrl,
+        String body,
+        Map<String, String> parameters,
+        Map<String, String> additionalHeaders,
+        Integer timeout)
+```
+
+- `parameters` become query-string values
+- `additionalHeaders` are merged into the request headers
+- `timeout` is per-request and is measured in milliseconds
+- `RestClient.DEFAULT_TIMEOUT_MS` is `100_000` when you pass `null`
+- `invokeMethodCsv(...)` forces `Accept: text/csv`
+- JSON is the normal default (`RestClient.prepareRequest(...)` adds `Accept: application/json` when needed)
+
+Example with query parameters and an explicit timeout:
+
+```java
+Map<String, String> parameters = new HashMap<String, String>();
+parameters.put("filter", "Name eq 'Admin'");
+parameters.put("fields", "Id,Name");
+
+String users = connection.invokeMethod(
+        Service.Core,
+        Method.Get,
+        "Users",
+        null,
+        parameters,
+        null,
+        30000);
+```
+
+Use `invokeMethodFull(...)` when the status code or headers matter:
+
+```java
+FullResponse response = connection.invokeMethodFull(
+        Service.Notification,
+        Method.Get,
+        "Status",
+        null,
+        null,
+        null,
+        null);
+
+System.out.println(response.getStatusCode());
+System.out.println(response.getBody());
+```
+
+## 3. Authentication context for API calls
+
+Choose the connection factory that matches the credential source you already have:
+
+- `Safeguard.connect(address, accessToken, apiVersion, ignoreSsl)`
+- `Safeguard.connect(address, provider, username, password, apiVersion, ignoreSsl)`
+- `Safeguard.connectPkce(...)` for PKCE-based interactive auth
+- `Safeguard.connect(address, certificatePath, certificatePassword, apiVersion, ignoreSsl)`
+- `Safeguard.connect(address, keystorePath, keystorePassword, certificateAlias, apiVersion, ignoreSsl)`
+- `Safeguard.connect(address, apiVersion, ignoreSsl)` for anonymous notification calls
+
+Repository examples:
+
+- `Samples/PasswordConnect/.../PasswordConnect.java` uses password auth, then calls `GET Me`
+- `Samples/CertificateConnect/.../CertificateConnect.java` uses a PFX/PKCS12 client certificate
+- `tests/safeguardjavaclient/.../SafeguardTests.java` exercises `Core`, `Appliance`, `Notification`, and `Management`
+
+If you expect a long-running process, wrap the connection with `Safeguard.Persist(connection)`.
+`PersistentSafeguardConnection` checks `getAccessTokenLifetimeRemaining()` before each
+`invokeMethod*` call and refreshes expired tokens automatically.
+
+### Management service calls
+
+`Service.Management` is only valid on a management connection:
+
+```java
+ISafeguardConnection management = connection.GetManagementServiceConnection(address);
+FullResponse info = management.invokeMethodFull(
+        Service.Management,
+        Method.Get,
+        "ApplianceInformation",
+        null,
+        null,
+        null,
+        null);
+```
+
+Do not try to use `Service.Management` on the original core/appliance/notification connection.
+
+## 4. CRUD examples (standard patterns)
+
+### Read: current user
+
+```java
+String me = connection.invokeMethod(
+        Service.Core,
+        Method.Get,
+        "Me",
+        null,
+        null,
+        null,
+        null);
+```
+
+### Create: add a new asset
+
+This follows the same pattern shown in `README.md` for `POST Assets`.
+
+```java
+String assetBody = "{"
+        + "\"Name\":\"linux.blue.vas\","
+        + "\"NetworkAddress\":\"linux.blue.vas\","
+        + "\"Description\":\"A new linux asset\","
+        + "\"PlatformId\":188,"
+        + "\"AssetPartitionId\":-1"
+        + "}";
+
+String created = connection.invokeMethod(
+        Service.Core,
+        Method.Post,
+        "Assets",
+        assetBody,
+        null,
+        null,
+        null);
+```
+
+### Update: change a setting
+
+`tests/safeguardjavaclient/.../SafeguardJavaClient.java` shows a real `PUT` example:
+
+```java
+ObjectNode body = mapper.createObjectNode();
+body.put("Value", newValue);
+
+connection.invokeMethod(
+        Service.Core,
+        Method.Put,
+        "Settings/" + URLEncoder.encode(settingName, "UTF-8").replace("+", "%20"),
+        mapper.writeValueAsString(body),
+        null,
+        null,
+        null);
+```
+
+### Delete: standard pattern
+
+There is no separate delete helper. Use `Method.Delete` with the resource-relative URL:
+
+```java
+connection.invokeMethod(
+        Service.Core,
+        Method.Delete,
+        "Assets/123",
+        null,
+        null,
+        null,
+        null);
+```
+
+The exact path still comes from Swagger for the service/version you are targeting.
+
+### CSV export
+
+If an endpoint supports CSV, call `invokeMethodCsv(...)` rather than manually setting
+headers. The SDK adds `Accept: text/csv` for you.
+
+## 5. Error handling and retry behavior
+
+The standard failure modes come directly from `SafeguardConnection` and `RestClient`:
+
+- `ArgumentException` for invalid SDK arguments such as an empty `relativeUrl`
+- `ObjectDisposedException` if you call the connection after `dispose()`
+- `SafeguardForJavaException("Access token is missing...")` if the connection was logged out
+- `SafeguardForJavaException("Unable to connect to web service ...")` when the HTTP call returns `null`
+- `SafeguardForJavaException("Error returned from Safeguard API, Error: <status> <body>")` for non-2xx responses
+
+There is **no general automatic retry loop** in `invokeMethod(...)` or `RestClient.exec*()`.
+If you need retries for idempotent operations, implement them in the caller.
+The built-in resilience feature is token refresh via `Safeguard.Persist(...)`, not HTTP retry.
+
+Practical guidance:
+
+- prefer `invokeMethodFull(...)` when debugging headers or status codes
+- log the service, method, relative URL, and sanitized query params
+- keep `timeout` explicit for slow endpoints instead of letting hung calls blend together
+- clear `char[]` credentials after use, matching the rest of the SDK
+
+## 6. Swagger / OpenAPI integration
+
+The repository `README.md` points to Swagger UI for endpoint discovery:
+
+```text
+https://<address>/service/<service>/swagger
+```
+
+Map Swagger service names to the SDK like this:
+
+- `core` -> `Service.Core`
+- `appliance` -> `Service.Appliance`
+- `notification` -> `Service.Notification`
+- `a2a` -> `Safeguard.A2A.getContext(...)` and `ISafeguardA2AContext`
+
+When translating Swagger into Java:
+
+1. drop the `/service/<service>/v<version>/` prefix from the path
+2. pass only the relative endpoint segment such as `Users`, `Me`, or `Settings/<id>`
+3. move query-string fields into the `parameters` map
+4. serialize the request body to a JSON string before calling `invokeMethod(...)`
+5. use the same `apiVersion` in your connection that you used while inspecting Swagger
+
+If Swagger shows an A2A endpoint, do **not** call it with `Service.A2A`; the SDK rejects
+that route and tells you to use the A2A-specific context.

--- a/.agents/skills/build-and-release/SKILL.md
+++ b/.agents/skills/build-and-release/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ci-cd-pipeline
+name: build-and-release
 description: >-
   Use when modifying Azure Pipelines, build templates, signing
   configuration, Maven Central publishing, GitHub Packages publishing,
@@ -7,7 +7,7 @@ description: >-
   strategy, and critical pipeline pitfalls.
 ---
 
-# CI/CD Pipeline
+# Build and Release
 
 The project uses **Azure Pipelines** (`azure-pipelines.yml`) with shared templates in
 `pipeline-templates/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,206 +1,96 @@
 # AGENTS.md -- SafeguardJava
 
-Java SDK for the One Identity Safeguard for Privileged Passwords REST API. Published on
-[Maven Central](https://central.sonatype.com/artifact/com.oneidentity.safeguard/safeguardjava)
-as `com.oneidentity.safeguard:safeguardjava`.
-
-Targets Java 8 source/target compatibility. Root package:
-`com.oneidentity.safeguard.safeguardjava`. Key dependencies: Apache HttpClient 5,
-Jackson Databind, Microsoft SignalR Java client, SLF4J logging, Gson (via SignalR).
+Java SDK for the One Identity Safeguard REST API.
+Artifact: `com.oneidentity.safeguard:safeguardjava`.
 
 ## Project structure
 
-```
-SafeguardJava/
-|-- src/main/java/com/oneidentity/safeguard/safeguardjava/
-|   |-- Safeguard.java                # Entry point: connect(), A2A, Events, Persist, SPS
-|   |-- ISafeguardConnection.java     # Primary connection interface
-|   |-- SafeguardConnection.java      # Base connection implementation
-|   |-- PersistentSafeguardConnection.java  # Auto-refreshing token decorator
-|   |-- ISafeguardA2AContext.java      # A2A context interface
-|   |-- SafeguardA2AContext.java       # A2A context implementation
-|   |-- SafeguardForPrivilegedSessions.java  # SPS entry point
-|   |-- ISafeguardSessionsConnection.java    # SPS connection interface
-|   |-- SafeguardSessionsConnection.java     # SPS connection implementation
-|   |-- authentication/               # IAuthenticationMechanism strategy pattern
-|   |   |-- IAuthenticationMechanism.java  # Auth interface contract
-|   |   |-- AuthenticatorBase.java    # Shared auth logic (rSTS token exchange)
-|   |   |-- PasswordAuthenticator.java    # Username/password via ROG or PKCE
-|   |   |-- CertificateAuthenticator.java # Client certificate (keystore/file/thumbprint)
-|   |   |-- AccessTokenAuthenticator.java # Pre-existing access token
-|   |   |-- AnonymousAuthenticator.java   # Unauthenticated connection
-|   |   `-- ManagementServiceAuthenticator.java  # Management service auth
-|   |-- event/                        # SignalR-based event system
-|   |   |-- ISafeguardEventListener.java  # Event listener interface
-|   |   |-- SafeguardEventListener.java   # Standard listener
-|   |   |-- PersistentSafeguardEventListener.java    # Auto-reconnecting listener
-|   |   |-- PersistentSafeguardA2AEventListener.java # A2A persistent listener
-|   |   `-- EventHandlerRegistry.java # Thread-safe handler dispatch
-|   |-- restclient/                   # RestClient wraps Apache HttpClient 5
-|   |-- data/                         # DTOs and enums (Service, Method, KeyFormat, etc.)
-|   `-- exceptions/                   # SafeguardForJavaException, ArgumentException, etc.
-|
-|-- tests/safeguardjavaclient/        # CLI test tool (interactive, not automated)
-|-- TestFramework/                    # PowerShell integration test framework
-|-- Samples/                          # Example projects (each with own pom.xml)
-|-- pipeline-templates/               # Azure Pipelines shared templates
-|-- pom.xml                           # Maven build descriptor
-|-- azure-pipelines.yml               # CI/CD pipeline definition
-|-- spotbugs-exclude.xml              # SpotBugs exclusions
-`-- settings/settings.xml             # Maven settings for release publishing
-```
+- `src/main/java/com/oneidentity/safeguard/safeguardjava/` — SDK sources (`Safeguard`, connections, A2A, auth, events, restclient, data, exceptions)
+- `tests/safeguardjavaclient/` — interactive live-appliance Java test client
+- `TestFramework/` — PowerShell appliance-test scaffolding
+- `Samples/` — standalone sample Maven projects
+- `.agents/skills/` — on-demand guidance
+- `pipeline-templates/`, `azure-pipelines.yml` — CI definitions
+- `pom.xml`, `settings/settings.xml`, `spotbugs-exclude.xml` — build, publishing, static analysis
 
-## Setup and build commands
+## Setup and build
 
 **Prerequisites:** JDK 8+ and Maven 3.0.5+.
 
 ```bash
-# Standard build (compile + editorconfig check + spotbugs + package)
 mvn package
-
-# Quick build (skip static analysis for faster iteration)
-mvn package -Dspotbugs.skip=true
-
-# Build with a specific version
-mvn package -Drevision=8.2.0
-
-# Clean build
-mvn clean package
-
-# Editorconfig check only
-mvn editorconfig:check
-```
-
-**PowerShell note:** Quote `-D` flags to prevent PowerShell's parameter parser from
-consuming them:
-
-```powershell
-# WRONG — PowerShell interprets -D as a parameter
-mvn package -Dspotbugs.skip=true
-
-# CORRECT
+mvn verify
+mvn clean verify
 mvn package "-Dspotbugs.skip=true"
 ```
 
-The build must complete with **0 errors**. The project enforces:
-- **EditorConfig** — LF line endings, UTF-8, 4-space indentation (via `editorconfig-maven-plugin`)
-- **SpotBugs** — static analysis for bug patterns (via `spotbugs-maven-plugin`)
+In PowerShell, quote `-D...` flags. For endpoint discovery, use
+`https://<address>/service/<service>/swagger`; see `api-patterns`.
 
-If you introduce a warning or violation, fix it before considering the change complete.
+## Linting
 
-## Line endings (CRITICAL on Windows)
+- `mvn editorconfig:check` — formatting and LF line endings
+- `mvn verify` — EditorConfig + SpotBugs through Maven
 
-The `.editorconfig` enforces `end_of_line = lf` for all text files, and the
-`editorconfig-maven-plugin` checks this during every build. On Windows, many tools
-(including editors and file creation APIs) default to CRLF line endings.
+## Testing
 
-**Every file you create or modify must have LF line endings.** If you are an AI agent
-creating files on Windows, post-process every file after creation or modification:
+There is no root-level mock/unit suite. Use:
 
-```powershell
-$content = [System.IO.File]::ReadAllText($path)
-$fixed = $content.Replace("`r`n", "`n")
-[System.IO.File]::WriteAllText($path, $fixed, [System.Text.UTF8Encoding]::new($false))
-```
+- `mvn verify`
+- `tests/safeguardjavaclient/`
+- `TestFramework/`
+- `Samples/`
 
-The `.editorconfig` excludes `*.{pfx,cer,pvk}` from line ending checks because these
-are binary/DER-encoded certificate files.
-
-## Exploring the Safeguard API
-
-The appliance exposes Swagger UI for each service at:
-- `https://<appliance>/service/core/swagger` — Core service (assets, users, policies, requests)
-- `https://<appliance>/service/appliance/swagger` — Appliance service (networking, diagnostics, backups)
-- `https://<appliance>/service/notification/swagger` — Notification service (status, events)
-- `https://<appliance>/service/event/swagger` — Event service (SignalR streaming)
-
-The default API version is **v4** (since SDK 7.0). Pass `apiVersion` parameter to use v3.
+See `testing-guide` for setup and workflow details.
 
 ## Code conventions
 
-### Sensitive data as `char[]`
+- keep passwords, tokens, API keys, and certificate passwords as `char[]`, then clear them
+- code against `I`-prefixed interfaces (`ISafeguardConnection`, `ISafeguardA2AContext`, `ISafeguardEventListener`, `IAuthenticationMechanism`)
+- call `dispose()` on connections, A2A contexts, and listeners
+- expect `ArgumentException`, `SafeguardForJavaException`, and `ObjectDisposedException`
+- preserve Java 8 compatibility and standard Java naming
+- do not recommend `ignoreSsl=true` for production without a warning
+- keep repository text files on **LF** line endings, especially on Windows
 
-Passwords, access tokens, and API keys are stored as `char[]` rather than `String` to
-allow explicit clearing from memory. Follow this pattern in all new code that handles
-credentials.
+## CI/CD
 
-### Interface-first design
+See the `build-and-release` skill.
 
-Every public type has a corresponding `I`-prefixed interface (`ISafeguardConnection`,
-`ISafeguardA2AContext`, `ISafeguardEventListener`, `IAuthenticationMechanism`). Code
-against interfaces, not implementations.
+## Security
 
-### Dispose pattern
+- never commit real passwords, API keys, access tokens, PFX/JKS files, private keys, or signing secrets
+- treat certificate material and retrieved secrets as sensitive runtime data
+- keep docs and samples scrubbed of real appliance addresses and credentials
+- prefer trusted certificates over disabling SSL checks
 
-Connections, A2A contexts, and event listeners implement a `dispose()` method that must
-be called to release resources. Every public method on these classes guards against
-use-after-dispose:
+## Versioning
 
-```java
-if (disposed) {
-    throw new ObjectDisposedException("ClassName");
-}
-```
-
-### Error handling
-
-- Parameter validation throws `ArgumentException`
-- HTTP failures throw `SafeguardForJavaException` with status code and response body
-- Null HTTP responses throw `SafeguardForJavaException("Unable to connect to ...")`
-- Disposed object access throws `ObjectDisposedException`
-
-### SSL/TLS
-
-- `ignoreSsl=true` uses `NoopHostnameVerifier` (development only)
-- Custom `HostnameVerifier` callback for fine-grained validation
-- Default: standard Java certificate validation
-- **Never recommend `ignoreSsl` for production** without explicit warning
-
-### Logging
-
-Uses **SLF4J** as the logging facade. Users supply their own SLF4J binding at runtime.
-
-### Naming conventions
-
-- Java standard naming: camelCase for fields/methods, PascalCase for classes
-- Interfaces use `I` prefix: `ISafeguardConnection`, `IAuthenticationMechanism`
-- Constants: UPPER_SNAKE_CASE
-- Package: `com.oneidentity.safeguard.safeguardjava`
-
-### Java version
-
-The SDK targets **Java 8** source/target compatibility. Do not use language features
-from Java 9+ (var, modules, records, sealed classes, etc.). All dependencies must be
-compatible with Java 8.
-
-## CI/CD overview
-
-The project uses **Azure Pipelines** (`azure-pipelines.yml`) with two jobs:
-- **PRValidation** — runs `mvn package` on pull requests (compile, lint, SpotBugs)
-- **BuildAndPublish** — on merge to `master`/`release-*`: build, sign, publish to
-  Maven Central + GitHub Packages, create GitHub Release
-
-See the `ci-cd-pipeline` skill for signing details, publishing configuration, and
-critical pipeline pitfalls.
-
-## Samples
-
-The `Samples/` directory contains standalone example projects, each with its own `pom.xml`:
-
-| Sample | Description |
-|---|---|
-| `PasswordConnect` | Password-based authentication and API call |
-| `CertificateConnect` | Certificate-based authentication via PFX/JKS |
-| `A2ARetrievalExample` | Application-to-application credential retrieval |
-| `EventListenerExample` | Persistent event listener with SignalR |
+- the Maven package version comes from `${revision}` in `pom.xml`
+- release automation injects the effective version with `-Drevision=...`
+- the default Safeguard API version is **v4**; pass `apiVersion` for older endpoints
+- preserve Java 8 compatibility in public APIs and examples
 
 ## On-demand skills
 
-The following skills contain deeper reference material loaded only when relevant.
-Read the `SKILL.md` when your current task matches the trigger.
-
 | Skill | When to read | File |
-|-------|-------------|------|
-| Testing Guide | Running tests, writing tests, investigating test failures, testing against a live appliance | `.agents/skills/testing-guide/SKILL.md` |
-| Architecture | Working on SDK internals, auth flows, event listeners, connection classes, adding new auth methods | `.agents/skills/architecture/SKILL.md` |
-| CI/CD Pipeline | Modifying Azure Pipelines, build templates, signing, publishing, release process | `.agents/skills/ci-cd-pipeline/SKILL.md` |
+|---|---|---|
+| Build and Release | Pipelines, signing, publishing, releases | `.agents/skills/build-and-release/SKILL.md` |
+| API Patterns | Standard REST calls, bodies, query params, responses | `.agents/skills/api-patterns/SKILL.md` |
+| A2A Workflow | A2A contexts, API keys, brokering, A2A events | `.agents/skills/a2a-workflow/SKILL.md` |
+| Testing Guide | Live-appliance validation and test workflows | `.agents/skills/testing-guide/SKILL.md` |
+| Architecture | SDK internals, auth flows, listeners, connections | `.agents/skills/architecture/SKILL.md` |
+
+## Samples
+
+| Sample | Description |
+|---|---|
+| `PasswordConnect` | Password auth + `GET Me` |
+| `CertificateConnect` | PKCS12/PFX certificate auth |
+| `A2ARetrievalExample` | A2A credential retrieval |
+| `EventListenerExample` | Persistent SignalR listener |
+
+## Keeping this file current
+
+Keep this file short and always-on. Move deep procedures into `.agents/skills/`, and
+update structure/build/test/security pointers when workflows change.


### PR DESCRIPTION
Implements the skills harmonization plan:

- Renamed `ci-cd-pipeline` → `build-and-release`
- Created `api-patterns` skill (ISafeguardConnection.invokeMethod, services, Swagger)
- Created `a2a-workflow` skill (ISafeguardA2AContext, credential retrieval, events)
- Updated AGENTS.md to standard template

Part of cross-repo effort to standardize agent skills across all Safeguard SDK repositories.