### PR TITLE
build: run CI on JDK 11; lock API surface to Java 8; bump to 8.2.2

### DIFF
--- a/pipeline-templates/build-steps.yml
+++ b/pipeline-templates/build-steps.yml
@@ -41,7 +41,7 @@ steps:
     mavenOptions: '-Xmx3072m'
     Options: '${{ parameters.mavenOptions }}'
     javaHomeOption: 'JDKVersion'
-    jdkVersionOption: '1.8'
+    jdkVersionOption: '1.11'
     jdkArchitectureOption: 'x64'
     publishJUnitResults: true
     testResultsFiles: '**/surefire-reports/TEST-*.xml'

--- a/pipeline-templates/global-variables.yml
+++ b/pipeline-templates/global-variables.yml
@@ -1,6 +1,6 @@
 variables:
   - name: semanticVersion
-    value: '8.2.1'
+    value: '8.2.2'
   - name: isTagBuild
     value: ${{ startsWith(variables['Build.SourceBranch'], 'refs/tags/') }}
   - name: isPrerelease

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <revision>8.2.1-SNAPSHOT</revision>
+        <revision>8.2.2-SNAPSHOT</revision>
         <gpgkeyname>keyname</gpgkeyname>
     </properties>
 
@@ -89,6 +89,7 @@
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
+                    <release>8</release>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
The v8.2.1 release pipeline (build 366149) failed before publish because `spotbugs-maven-plugin:4.9.8.3` requires JDK 11 to execute, but the Maven build task was pinned to `jdkVersionOption: '1.8'`. As a result the v8.2.1 security content was tagged but never landed on Maven Central.

### Changes

- **`pipeline-templates/build-steps.yml`** `jdkVersionOption: '1.8'` → `'1.11'` (lets spotbugs run).
- **`pom.xml`** add `<release>8</release>` to `maven-compiler-plugin` alongside the existing `<source>/<target>1.8`. This explicitly restricts the API surface to the Java 8 stdlib, which prevents accidental use of Java 9+ methods (e.g. `String.strip()`, `List.of()`) that would compile fine on JDK 11 but `NoSuchMethodError` at runtime on customer JDK 8 deployments.
- **`pom.xml`** `<revision>` `8.2.1-SNAPSHOT` → `8.2.2-SNAPSHOT`
- **`pipeline-templates/global-variables.yml`** `semanticVersion` `8.2.1` → `8.2.2`

No source changes. The v8.2.1 security content (TLS 1.2 floor in RestClient + EventListener) ships unchanged under the 8.2.2 label.

### Verification

Locally on JDK 11:

``
mvn -DskipTests -Drevision=8.2.2 verify
``

Produces `target/safeguardjava-8.2.2.jar`. `javap -v` on a compiled class reports `major version: 52` (Java 8 bytecode), confirming customer compatibility is preserved.

### Release note

After merge, push tag `v8.2.2` to trigger Maven Central publish. The orphan `v8.2.1` tag will remain in history pointing at the failed-publish commit; no harm leaving it.
