### PR TITLE
Add Device Code (RFC 8628) authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,47 @@ System.out.println(connection.invokeMethod(Service.Core, Method.Get, "Me", null,
 connection.dispose();
 ```
 
+### Device Code Authentication
+
+Device Code (OAuth 2.0 Device Authorization Grant, RFC 8628) is designed for
+**headless or no-browser callers** such as containers, SSH sessions, CI jobs, and
+IoT or otherwise constrained devices. The SDK never opens a browser. Instead, the
+caller displays a verification URL and a user code through a required callback, the
+user authenticates in their own browser on any device, and the SDK polls until the
+login succeeds, is denied, expires, or is cancelled.
+
+```Java
+ISafeguardConnection connection = Safeguard.connectDeviceCode(
+        "safeguard.sample.corp",
+        info -> {
+            // Sample display behavior — the library never prints or opens a browser.
+            String url = info.getVerificationUriComplete() != null
+                    ? info.getVerificationUriComplete() : info.getVerificationUri();
+            System.out.println("To sign in, visit " + url + " and enter code " + info.getUserCode());
+        },
+        null,   // optional DeviceCodeLoginParameters (scope, client id, polling interval, cancel hook)
+        null,   // apiVersion
+        true);  // ignoreSsl
+System.out.println(connection.invokeMethod(Service.Core, Method.Get, "Me", null, null, null));
+connection.dispose();
+```
+
+The display callback receives only display values (`userCode`, `verificationUri`,
+`verificationUriComplete`, `expiresIn`, and `interval`); the internal `device_code`
+is never exposed. The polling interval is automatically increased when the appliance
+asks the client to slow down, cancellation is caller-driven through
+`DeviceCodeLoginParameters.setIsCancelled(...)`, and the deadline is always the
+appliance's `expires_in` value.
+
+> **Appliance prerequisite:** the Device Code grant must be enabled on the appliance
+> under **Settings → OAuth 2.0 Grant Types** (the API setting
+> `Settings/Allowed OAuth2 Grant Types` must include `DeviceCode`). When it is
+> disabled, the appliance returns the marker
+> `OAuth2 device code grant type is not allowed.` and the SDK throws a clear error
+> instructing an administrator to enable it.
+
+A runnable example is in [Samples/DeviceCodeConnect](Samples/DeviceCodeConnect/).
+
 Calling the simple 'Me' endpoint provides information about the currently logged
 on user.
 

--- a/Samples/DeviceCodeConnect/README.md
+++ b/Samples/DeviceCodeConnect/README.md
@@ -1,0 +1,46 @@
+# DeviceCodeConnect Sample
+
+Demonstrates connecting to Safeguard using the OAuth 2.0 Device Authorization
+Grant (Device Code flow, RFC 8628). This flow is designed for **headless or
+no-browser** environments (containers, SSH sessions, CI jobs, IoT or constrained
+devices).
+
+The SDK never opens a browser. This sample prints a verification URL and a user
+code through the required display callback; you complete authentication in a
+browser on any device, and the SDK polls until login succeeds, is denied,
+expires, or is cancelled.
+
+> Printing the URL and code is **sample behavior**. The library only hands those
+> values to the callback — it never prints, logs, or opens a browser itself, and
+> it never exposes the internal `device_code`.
+
+## Appliance prerequisite
+
+The Device Code grant must be enabled on the appliance under
+**Settings → OAuth 2.0 Grant Types** (the API setting
+`Settings/Allowed OAuth2 Grant Types` must include `DeviceCode`). When it is
+disabled, the SDK throws a clear error instructing an administrator to enable it.
+
+## Building
+
+```bash
+mvn clean package
+```
+
+## Running
+
+```bash
+java -jar target/device-code-connect-1.0-SNAPSHOT-jar-with-dependencies.jar <appliance>
+```
+
+### Arguments
+
+| Argument | Description | Default |
+|----------|-------------|---------|
+| appliance | IP or hostname of Safeguard appliance | (required) |
+
+### Example
+
+```bash
+java -jar target/device-code-connect-1.0-SNAPSHOT-jar-with-dependencies.jar safeguard.example.com
+```

--- a/Samples/DeviceCodeConnect/pom.xml
+++ b/Samples/DeviceCodeConnect/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.oneidentity.safeguard.samples</groupId>
+    <artifactId>device-code-connect</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>SafeguardJava Sample - Device Code Connect</name>
+
+    <properties>
+        <maven.compiler.release>11</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.oneidentity.safeguard</groupId>
+            <artifactId>safeguardjava</artifactId>
+            <version>8.3.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+    <repositories>
+        <repository>
+            <id>central-snapshots</id>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+            <releases><enabled>false</enabled></releases>
+            <snapshots><enabled>true</enabled></snapshots>
+        </repository>
+    </repositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>com.oneidentity.safeguard.samples.DeviceCodeConnect</mainClass>
+                        </manifest>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/Samples/DeviceCodeConnect/src/main/java/com/oneidentity/safeguard/samples/DeviceCodeConnect.java
+++ b/Samples/DeviceCodeConnect/src/main/java/com/oneidentity/safeguard/samples/DeviceCodeConnect.java
@@ -1,0 +1,67 @@
+package com.oneidentity.safeguard.samples;
+
+import com.oneidentity.safeguard.safeguardjava.ISafeguardConnection;
+import com.oneidentity.safeguard.safeguardjava.Safeguard;
+import com.oneidentity.safeguard.safeguardjava.data.Method;
+import com.oneidentity.safeguard.safeguardjava.data.Service;
+
+/**
+ * Demonstrates connecting to Safeguard using the OAuth 2.0 Device Authorization
+ * Grant (Device Code flow, RFC 8628).
+ * <p>
+ * This flow is intended for headless or no-browser environments. The SDK never
+ * opens a browser; this sample prints the verification URL and user code, and
+ * the user completes authentication in a browser on any device. The SDK polls
+ * until the login succeeds, is denied, expires, or is cancelled.
+ * <p>
+ * The Device Code grant must be enabled on the appliance under
+ * Settings -&gt; OAuth 2.0 Grant Types.
+ */
+public class DeviceCodeConnect {
+
+    public static void main(String[] args) {
+        if (args.length < 1) {
+            System.out.println("Usage: DeviceCodeConnect <appliance>");
+            System.out.println();
+            System.out.println("  appliance  - IP address or hostname of Safeguard appliance");
+            return;
+        }
+
+        String appliance = args[0];
+
+        ISafeguardConnection connection = null;
+        try {
+            // Connect using Device Code. The caller-provided callback is responsible
+            // for displaying the verification URL and user code — printing here is
+            // sample behavior, not library behavior. Set ignoreSsl=true for lab
+            // environments; use a HostnameVerifier in production.
+            connection = Safeguard.connectDeviceCode(appliance, info -> {
+                String url = info.getVerificationUriComplete() != null
+                        ? info.getVerificationUriComplete()
+                        : info.getVerificationUri();
+                System.out.println();
+                System.out.println("To sign in, use a web browser to open:");
+                System.out.println("    " + url);
+                System.out.println("and enter the code:");
+                System.out.println("    " + info.getUserCode());
+                System.out.println();
+                System.out.println("Waiting for you to complete authentication "
+                        + "(expires in " + info.getExpiresIn() + " seconds)...");
+            }, null, null, true);
+
+            // Call the "Me" endpoint to get info about the authenticated user
+            String me = connection.invokeMethod(Service.Core, Method.Get, "Me",
+                    null, null, null, null);
+            System.out.println("Current user info:");
+            System.out.println(me);
+
+        } catch (Exception ex) {
+            System.err.println("Error: " + ex.getMessage());
+            ex.printStackTrace();
+        } finally {
+            if (connection != null) {
+                connection.dispose();
+            }
+        }
+    }
+}

--- a/Samples/README.md
+++ b/Samples/README.md
@@ -15,6 +15,7 @@ Each sample is a self-contained Maven project that can be built and run independ
 |--------|-------------|
 | [PasswordConnect](PasswordConnect/) | Connect using username and password, call the API |
 | [CertificateConnect](CertificateConnect/) | Connect using a PKCS12 client certificate file |
+| [DeviceCodeConnect](DeviceCodeConnect/) | Connect using the OAuth 2.0 Device Code flow (headless, no browser) |
 | [A2ARetrievalExample](A2ARetrievalExample/) | Retrieve a credential via Application-to-Application (A2A) |
 | [EventListenerExample](EventListenerExample/) | Subscribe to real-time Safeguard events via SignalR |
 

--- a/TestFramework/Suites/Suite-DeviceCodeAuth.ps1
+++ b/TestFramework/Suites/Suite-DeviceCodeAuth.ps1
@@ -1,0 +1,90 @@
+@{
+    Name        = "Device Code Authentication"
+    Description = "Tests the OAuth 2.0 Device Authorization Grant (Device Code) flow against a live appliance"
+    Tags        = @("auth", "devicecode")
+
+    Setup = {
+        param($Context)
+
+        if ([string]::IsNullOrEmpty($Context.Appliance) -or [string]::IsNullOrEmpty($Context.AdminPassword)) {
+            return
+        }
+
+        # Capture the current Allowed OAuth2 Grant Types so the suite can toggle DeviceCode
+        # and restore the original value during cleanup.
+        $settings = Invoke-SgJSafeguardApi -Context $Context `
+            -Service Core -Method Get -RelativeUrl "Settings" -Pkce
+        $grant = $settings | Where-Object { $_.Name -eq "Allowed OAuth2 Grant Types" } | Select-Object -First 1
+        $originalValue = if ($grant) { [string]$grant.Value } else { "" }
+
+        $Context.SuiteData.OriginalGrantValue = $originalValue
+        $Context.SuiteData.OriginalGrantTypes = @(
+            $originalValue -split "," | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne "" }
+        )
+
+        Register-SgJTestCleanup -Description "Restore Allowed OAuth2 Grant Types" -Action {
+            param($Context)
+            Invoke-SgJSafeguardApi -Context $Context `
+                -Service Core -Method Put -RelativeUrl "Settings/Allowed%20OAuth2%20Grant%20Types" `
+                -Body @{ Name = "Allowed OAuth2 Grant Types"; Value = $Context.SuiteData.OriginalGrantValue } -Pkce | Out-Null
+        }
+    }
+
+    Execute = {
+        param($Context)
+
+        if ([string]::IsNullOrEmpty($Context.Appliance) -or [string]::IsNullOrEmpty($Context.AdminPassword)) {
+            Test-SgJSkip "Device Code authentication" "Appliance/admin credentials not configured"
+            return
+        }
+
+        $deviceCodeArgs = "-a $($Context.Appliance) -x --device-code"
+
+        # Helper to write the Allowed OAuth2 Grant Types setting.
+        $setGrantTypes = {
+            param($Context, [string[]]$Types)
+            $value = ($Types -join ", ")
+            Invoke-SgJSafeguardApi -Context $Context `
+                -Service Core -Method Put -RelativeUrl "Settings/Allowed%20OAuth2%20Grant%20Types" `
+                -Body @{ Name = "Allowed OAuth2 Grant Types"; Value = $value } -Pkce | Out-Null
+        }
+
+        # --- Disabled grant: DeviceCode removed from the allowed grant types ---
+        $withoutDeviceCode = @($Context.SuiteData.OriginalGrantTypes | Where-Object { $_ -ne "DeviceCode" })
+        if ($withoutDeviceCode.Count -eq 0) { $withoutDeviceCode = @("ResourceOwner") }
+        & $setGrantTypes $Context $withoutDeviceCode
+
+        Test-SgJAssertThrows "Device Code with grant disabled is rejected" {
+            Invoke-SgJSafeguardTool -Arguments $deviceCodeArgs -ParseJson $false | Out-Null
+        }
+
+        Test-SgJAssert "Device Code disabled error instructs to enable the grant" {
+            $message = $null
+            try {
+                Invoke-SgJSafeguardTool -Arguments $deviceCodeArgs -ParseJson $false | Out-Null
+            }
+            catch {
+                $message = $_.Exception.Message
+            }
+            $null -ne $message -and ($message -match "(?i)grant type")
+        }
+
+        # --- Enabled grant: DeviceCode present in the allowed grant types ---
+        $withDeviceCode = @($Context.SuiteData.OriginalGrantTypes)
+        if ($withDeviceCode -notcontains "DeviceCode") { $withDeviceCode += "DeviceCode" }
+        & $setGrantTypes $Context $withDeviceCode
+
+        Test-SgJAssert "Device Code enabled flow returns a verification URL and user code" {
+            $result = Invoke-SgJSafeguardTool -Arguments $deviceCodeArgs -ParseJson $true
+            $display = $result.DeviceCodeDisplay
+            $null -ne $display `
+                -and -not [string]::IsNullOrEmpty([string]$display.VerificationUri) `
+                -and -not [string]::IsNullOrEmpty([string]$display.UserCode)
+        }
+    }
+
+    Cleanup = {
+        param($Context)
+        # Grant types are restored via the registered cleanup action.
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <revision>8.2.2-SNAPSHOT</revision>
+        <revision>8.3.0-SNAPSHOT</revision>
         <gpgkeyname>keyname</gpgkeyname>
     </properties>
 

--- a/src/main/java/com/oneidentity/safeguard/safeguardjava/IDeviceCodeDisplayCallback.java
+++ b/src/main/java/com/oneidentity/safeguard/safeguardjava/IDeviceCodeDisplayCallback.java
@@ -1,0 +1,27 @@
+package com.oneidentity.safeguard.safeguardjava;
+
+import com.oneidentity.safeguard.safeguardjava.data.DeviceCodeInfo;
+
+/**
+ * Callback used by the Device Code (OAuth 2.0 Device Authorization Grant,
+ * RFC 8628) login flow to hand the verification URL and user code to the
+ * calling application for display.
+ * <p>
+ * The SafeguardJava SDK never opens a browser, prints, or logs these values on
+ * the caller's behalf. The application is responsible for presenting the
+ * verification URL and user code to the end user through whatever channel is
+ * appropriate (console, GUI, log, etc.).
+ * <p>
+ * The callback is <b>required</b> and is invoked exactly once after a successful
+ * device authorization response and before polling begins. It never receives
+ * the raw {@code device_code}.
+ */
+public interface IDeviceCodeDisplayCallback {
+
+    /**
+     * Called once with the device authorization values to display to the user.
+     *
+     * @param info The verification URL, user code, and related display values.
+     */
+    void display(DeviceCodeInfo info);
+}

--- a/src/main/java/com/oneidentity/safeguard/safeguardjava/Safeguard.java
+++ b/src/main/java/com/oneidentity/safeguard/safeguardjava/Safeguard.java
@@ -3,6 +3,8 @@ package com.oneidentity.safeguard.safeguardjava;
 import com.oneidentity.safeguard.safeguardjava.authentication.AccessTokenAuthenticator;
 import com.oneidentity.safeguard.safeguardjava.authentication.AnonymousAuthenticator;
 import com.oneidentity.safeguard.safeguardjava.authentication.CertificateAuthenticator;
+import com.oneidentity.safeguard.safeguardjava.authentication.DeviceCodeAuthenticator;
+import com.oneidentity.safeguard.safeguardjava.authentication.DeviceCodeLoginParameters;
 import com.oneidentity.safeguard.safeguardjava.authentication.IAuthenticationMechanism;
 import com.oneidentity.safeguard.safeguardjava.authentication.PasswordAuthenticator;
 import com.oneidentity.safeguard.safeguardjava.authentication.PkceAuthenticator;
@@ -232,6 +234,95 @@ public final class Safeguard {
 
         return getConnection(new PkceAuthenticator(networkAddress, provider, username, password,
                 secondaryPassword, version, sslIgnore, null));
+    }
+
+    /**
+     *  Connect to Safeguard API using the OAuth 2.0 Device Authorization Grant
+     *  (Device Code flow, RFC 8628).
+     *  <p>
+     *  This method is intended for headless or no-browser callers (containers,
+     *  SSH sessions, CI jobs, IoT or constrained devices). The SDK never opens a
+     *  browser; instead the caller-provided {@code displayCallback} is invoked
+     *  once with the verification URL and user code, the user authenticates in
+     *  their own browser on any device, and the SDK polls until success,
+     *  denial, expiry, or cancellation. The display callback receives display
+     *  values only and never the raw {@code device_code}. The
+     *  {@code pollingIntervalSeconds} parameter is automatically increased when
+     *  the appliance returns {@code slow_down}; cancellation is caller-driven and
+     *  the deadline is the appliance {@code expires_in} value.
+     *  <p>
+     *  The Device Code grant must be enabled on the appliance under
+     *  Settings -&gt; OAuth 2.0 Grant Types (API setting
+     *  {@code Settings/Allowed OAuth2 Grant Types} must include {@code DeviceCode});
+     *  otherwise a clear error is thrown.
+     *
+     *  @param networkAddress Network address of Safeguard appliance.
+     *  @param displayCallback Required callback used to display the verification URL and user code.
+     *  @param parameters Optional Device Code parameters (scope, client id, polling interval, cancel hook); may be null.
+     *  @param apiVersion Target API version to use.
+     *  @param ignoreSsl Ignore server certificate validation.
+     *  @return Reusable Safeguard API connection.
+     *  @throws ObjectDisposedException Object has already been disposed.
+     *  @throws ArgumentException Invalid argument.
+     *  @throws SafeguardForJavaException General Safeguard for Java exception.
+     */
+    public static ISafeguardConnection connectDeviceCode(String networkAddress,
+            IDeviceCodeDisplayCallback displayCallback, DeviceCodeLoginParameters parameters,
+            Integer apiVersion, Boolean ignoreSsl)
+            throws ObjectDisposedException, ArgumentException, SafeguardForJavaException {
+        int version = DEFAULTAPIVERSION;
+        if (apiVersion != null) {
+            version = apiVersion;
+        }
+
+        boolean sslIgnore = false;
+        if (ignoreSsl != null) {
+            sslIgnore = ignoreSsl;
+        }
+
+        return getConnection(new DeviceCodeAuthenticator(networkAddress, displayCallback, parameters, version,
+                sslIgnore, null));
+    }
+
+    /**
+     *  Connect to Safeguard API using the OAuth 2.0 Device Authorization Grant
+     *  (Device Code flow, RFC 8628).
+     *  <p>
+     *  This method is intended for headless or no-browser callers. The SDK never
+     *  opens a browser; the caller-provided {@code displayCallback} is invoked
+     *  once with the verification URL and user code, and the SDK polls until
+     *  success, denial, expiry, or cancellation. The display callback receives
+     *  display values only and never the raw {@code device_code}. The
+     *  {@code pollingIntervalSeconds} parameter is automatically increased when
+     *  the appliance returns {@code slow_down}; cancellation is caller-driven and
+     *  the deadline is the appliance {@code expires_in} value.
+     *  <p>
+     *  The Device Code grant must be enabled on the appliance under
+     *  Settings -&gt; OAuth 2.0 Grant Types (API setting
+     *  {@code Settings/Allowed OAuth2 Grant Types} must include {@code DeviceCode});
+     *  otherwise a clear error is thrown.
+     *
+     *  @param networkAddress Network address of Safeguard appliance.
+     *  @param displayCallback Required callback used to display the verification URL and user code.
+     *  @param parameters Optional Device Code parameters (scope, client id, polling interval, cancel hook); may be null.
+     *  @param validationCallback Callback function to be executed during SSL certificate validation.
+     *  @param apiVersion Target API version to use.
+     *  @return Reusable Safeguard API connection.
+     *  @throws ObjectDisposedException Object has already been disposed.
+     *  @throws ArgumentException Invalid argument.
+     *  @throws SafeguardForJavaException General Safeguard for Java exception.
+     */
+    public static ISafeguardConnection connectDeviceCode(String networkAddress,
+            IDeviceCodeDisplayCallback displayCallback, DeviceCodeLoginParameters parameters,
+            HostnameVerifier validationCallback, Integer apiVersion)
+            throws ObjectDisposedException, ArgumentException, SafeguardForJavaException {
+        int version = DEFAULTAPIVERSION;
+        if (apiVersion != null) {
+            version = apiVersion;
+        }
+
+        return getConnection(new DeviceCodeAuthenticator(networkAddress, displayCallback, parameters, version,
+                false, validationCallback));
     }
 
     /**
@@ -875,6 +966,83 @@ public final class Safeguard {
 
             return new PersistentSafeguardEventListener(getConnection(
                     new PasswordAuthenticator(networkAddress, provider, username, password, version, false, validationCallback)));
+        }
+
+        /**
+         *  Get a persistent event listener using the OAuth 2.0 Device
+         *  Authorization Grant (Device Code flow, RFC 8628) for authentication.
+         *  <p>
+         *  The SDK never opens a browser; the caller-provided
+         *  {@code displayCallback} is invoked once with the verification URL and
+         *  user code, and the SDK polls until the user authorizes. The display
+         *  callback receives display values only and never the raw
+         *  {@code device_code}. The Device Code grant must be enabled on the
+         *  appliance under Settings -&gt; OAuth 2.0 Grant Types.
+         *
+         *  @param networkAddress Network address of Safeguard appliance.
+         *  @param displayCallback Required callback used to display the verification URL and user code.
+         *  @param parameters Optional Device Code parameters; may be null.
+         *  @param apiVersion Target API version to use.
+         *  @param ignoreSsl Ignore server certificate validation.
+         *
+         *  @return New persistent Safeguard event listener.
+         *  @throws ObjectDisposedException Object has already been disposed.
+         *  @throws SafeguardForJavaException General Safeguard for Java exception.
+         *  @throws ArgumentException Invalid argument.
+         */
+        public static ISafeguardEventListener getPersistentEventListener(String networkAddress,
+                IDeviceCodeDisplayCallback displayCallback, DeviceCodeLoginParameters parameters,
+                Integer apiVersion, Boolean ignoreSsl)
+                throws ObjectDisposedException, SafeguardForJavaException, ArgumentException {
+
+            int version = DEFAULTAPIVERSION;
+            if (apiVersion != null) {
+                version = apiVersion;
+            }
+
+            boolean sslIgnore = false;
+            if (ignoreSsl != null) {
+                sslIgnore = ignoreSsl;
+            }
+
+            return new PersistentSafeguardEventListener(getConnection(
+                    new DeviceCodeAuthenticator(networkAddress, displayCallback, parameters, version, sslIgnore, null)));
+        }
+
+        /**
+         *  Get a persistent event listener using the OAuth 2.0 Device
+         *  Authorization Grant (Device Code flow, RFC 8628) for authentication.
+         *  <p>
+         *  The SDK never opens a browser; the caller-provided
+         *  {@code displayCallback} is invoked once with the verification URL and
+         *  user code, and the SDK polls until the user authorizes. The display
+         *  callback receives display values only and never the raw
+         *  {@code device_code}. The Device Code grant must be enabled on the
+         *  appliance under Settings -&gt; OAuth 2.0 Grant Types.
+         *
+         *  @param networkAddress Network address of Safeguard appliance.
+         *  @param displayCallback Required callback used to display the verification URL and user code.
+         *  @param parameters Optional Device Code parameters; may be null.
+         *  @param validationCallback Callback function to be executed during SSL certificate validation.
+         *  @param apiVersion Target API version to use.
+         *
+         *  @return New persistent Safeguard event listener.
+         *  @throws ObjectDisposedException Object has already been disposed.
+         *  @throws SafeguardForJavaException General Safeguard for Java exception.
+         *  @throws ArgumentException Invalid argument.
+         */
+        public static ISafeguardEventListener getPersistentEventListener(String networkAddress,
+                IDeviceCodeDisplayCallback displayCallback, DeviceCodeLoginParameters parameters,
+                HostnameVerifier validationCallback, Integer apiVersion)
+                throws ObjectDisposedException, SafeguardForJavaException, ArgumentException {
+
+            int version = DEFAULTAPIVERSION;
+            if (apiVersion != null) {
+                version = apiVersion;
+            }
+
+            return new PersistentSafeguardEventListener(getConnection(
+                    new DeviceCodeAuthenticator(networkAddress, displayCallback, parameters, version, false, validationCallback)));
         }
 
         /**

--- a/src/main/java/com/oneidentity/safeguard/safeguardjava/authentication/DeviceCodeAuthenticator.java
+++ b/src/main/java/com/oneidentity/safeguard/safeguardjava/authentication/DeviceCodeAuthenticator.java
@@ -1,0 +1,410 @@
+package com.oneidentity.safeguard.safeguardjava.authentication;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oneidentity.safeguard.safeguardjava.IDeviceCodeDisplayCallback;
+import com.oneidentity.safeguard.safeguardjava.Utils;
+import com.oneidentity.safeguard.safeguardjava.data.DeviceCodeInfo;
+import com.oneidentity.safeguard.safeguardjava.data.JsonObject;
+import com.oneidentity.safeguard.safeguardjava.exceptions.ArgumentException;
+import com.oneidentity.safeguard.safeguardjava.exceptions.ObjectDisposedException;
+import com.oneidentity.safeguard.safeguardjava.exceptions.SafeguardForJavaException;
+import java.util.Locale;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import javax.net.ssl.HostnameVerifier;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+
+/**
+ * Authenticator that implements the OAuth 2.0 Device Authorization Grant
+ * (RFC 8628) against the Safeguard rSTS.
+ * <p>
+ * This authenticator only performs RFC 8628 token <i>acquisition</i>: it
+ * requests a device code, hands the verification URL and user code to a
+ * caller-provided {@link IDeviceCodeDisplayCallback}, and then polls the rSTS
+ * token endpoint until the user authorizes (or the flow is denied, expires, or
+ * is cancelled). The resulting rSTS token is exchanged for a Safeguard
+ * {@code UserToken} by the inherited {@link AuthenticatorBase#refreshAccessToken()}.
+ * <p>
+ * The library never opens a browser, prints, or logs the verification values,
+ * and never exposes the raw {@code device_code}.
+ */
+public class DeviceCodeAuthenticator extends AuthenticatorBase {
+
+    private static final Logger logger = LoggerFactory.getLogger(DeviceCodeAuthenticator.class);
+
+    private static final String DEVICE_LOGIN_PATH = "oauth2/DeviceLogin";
+    private static final String TOKEN_PATH = "oauth2/token";
+    private static final String DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
+
+    // Marker (case-insensitive) emitted by the appliance when the Device Code grant is disabled.
+    // The disabled response body is HTML, so it is matched by substring rather than JSON-parsed.
+    private static final String DISABLED_GRANT_MARKER = "device code grant type is not allowed";
+
+    private static final int SLOW_DOWN_INCREMENT_SECONDS = 5;
+
+    private boolean disposed;
+
+    private final IDeviceCodeDisplayCallback displayCallback;
+    private final DeviceCodeLoginParameters parameters;
+
+    private int currentPollingIntervalSeconds;
+
+    /**
+     * Creates a Device Code authenticator.
+     *
+     * @param networkAddress Network address of Safeguard appliance.
+     * @param displayCallback Required callback used to display the verification URL and user code.
+     * @param parameters Optional Device Code parameters; defaults are used when null.
+     * @param apiVersion Target API version.
+     * @param ignoreSsl Whether to ignore SSL certificate validation.
+     * @param validationCallback Optional hostname verifier callback.
+     * @throws ArgumentException If the display callback is null.
+     */
+    public DeviceCodeAuthenticator(String networkAddress, IDeviceCodeDisplayCallback displayCallback,
+            DeviceCodeLoginParameters parameters, int apiVersion, boolean ignoreSsl,
+            HostnameVerifier validationCallback) throws ArgumentException {
+        super(networkAddress, apiVersion, ignoreSsl, validationCallback);
+        if (displayCallback == null) {
+            throw new ArgumentException("The displayCallback parameter can not be null");
+        }
+        this.displayCallback = displayCallback;
+        this.parameters = parameters == null ? new DeviceCodeLoginParameters() : parameters;
+        this.currentPollingIntervalSeconds = this.parameters.getPollingIntervalSeconds();
+    }
+
+    @Override
+    public String getId() {
+        return "DeviceCode";
+    }
+
+    @Override
+    protected char[] getRstsTokenInternal() throws ObjectDisposedException, SafeguardForJavaException {
+        if (disposed) {
+            throw new ObjectDisposedException("DeviceCodeAuthenticator");
+        }
+
+        String clientId = parameters.getClientId();
+        String scope = parameters.getScope();
+
+        // Step 1 - Request device code.
+        RstsResponse deviceResponse = requestDeviceCode(clientId, scope);
+
+        // Step 2 - Detect a disabled grant reactively (non-200 HTML; do not JSON-parse).
+        if (deviceResponse.getStatusCode() != 200) {
+            String body = deviceResponse.getBody() == null ? "" : deviceResponse.getBody();
+            if (body.toLowerCase(Locale.ROOT).contains(DISABLED_GRANT_MARKER)) {
+                throw new SafeguardForJavaException("The OAuth 2.0 Device Code grant type is not enabled on this "
+                        + "Safeguard appliance. An administrator must enable it under "
+                        + "Settings -> OAuth 2.0 Grant Types (API setting 'Settings/Allowed OAuth2 Grant Types' "
+                        + "must include 'DeviceCode').");
+            }
+            throw new SafeguardForJavaException(String.format(
+                    "Error requesting device code from RSTS, Error: %d %s", deviceResponse.getStatusCode(), body));
+        }
+
+        // Parse the device authorization response only on HTTP 200.
+        JsonNode node = parseJson(deviceResponse.getBody());
+        String deviceCode = requireString(node, "device_code");
+        String userCode = requireString(node, "user_code");
+        String verificationUri = requireString(node, "verification_uri");
+        int expiresIn = requireInt(node, "expires_in");
+        String verificationUriComplete = optionalString(node, "verification_uri_complete");
+        Integer interval = optionalInt(node, "interval");
+
+        // Step 3 - Display (the device_code is never exposed to the caller).
+        DeviceCodeInfo info = new DeviceCodeInfo(userCode, verificationUri, verificationUriComplete, expiresIn, interval);
+        displayCallback.display(info);
+
+        // Step 4 - Poll until success, denial, expiry, deadline, or cancellation.
+        return pollForToken(clientId, deviceCode, expiresIn);
+    }
+
+    private char[] pollForToken(String clientId, String deviceCode, int expiresIn)
+            throws SafeguardForJavaException {
+
+        long deadlineMillis = monotonicMillis() + (long) expiresIn * 1000L;
+        currentPollingIntervalSeconds = parameters.getPollingIntervalSeconds();
+
+        while (true) {
+            if (isCancelled()) {
+                throw new SafeguardForJavaException("Device code authentication was cancelled");
+            }
+            if (monotonicMillis() >= deadlineMillis) {
+                throw new SafeguardForJavaException(
+                        "Device code authentication timed out before the user completed authorization");
+            }
+
+            waitInterval(currentPollingIntervalSeconds);
+
+            if (isCancelled()) {
+                throw new SafeguardForJavaException("Device code authentication was cancelled");
+            }
+
+            RstsResponse response = requestToken(clientId, deviceCode);
+
+            if (response.getStatusCode() == 200) {
+                JsonNode tokenNode = parseJson(response.getBody());
+                JsonNode accessToken = tokenNode.get("access_token");
+                if (accessToken == null || accessToken.isNull() || Utils.isNullOrEmpty(accessToken.asText())) {
+                    throw new SafeguardForJavaException(
+                            "Device code token response did not contain an access_token");
+                }
+                return accessToken.asText().toCharArray();
+            }
+
+            String error = extractError(response.getBody());
+            if ("authorization_pending".equalsIgnoreCase(error)) {
+                logger.debug("Device code authorization pending");
+            } else if ("slow_down".equalsIgnoreCase(error)) {
+                currentPollingIntervalSeconds += SLOW_DOWN_INCREMENT_SECONDS;
+                logger.debug("Device code polling slowed down to {} seconds", currentPollingIntervalSeconds);
+            } else if ("access_denied".equalsIgnoreCase(error)) {
+                throw new SafeguardForJavaException("Device code authentication was denied by the user");
+            } else if ("expired_token".equalsIgnoreCase(error)) {
+                throw new SafeguardForJavaException(
+                        "The device code expired before the user completed authorization");
+            } else {
+                throw new SafeguardForJavaException(String.format(
+                        "Error polling for device code token, Error: %d %s",
+                        response.getStatusCode(), response.getBody()));
+            }
+        }
+    }
+
+    private boolean isCancelled() {
+        try {
+            Boolean cancelled = parameters.getIsCancelled().get();
+            return Boolean.TRUE.equals(cancelled);
+        } catch (RuntimeException ex) {
+            logger.warn("Cancel hook threw an exception; treating as not cancelled", ex);
+            return false;
+        }
+    }
+
+    /**
+     * Requests a device code from the rSTS. Exposed for testability.
+     *
+     * @param clientId OAuth client id (may be empty).
+     * @param scope Scope selecting the authentication provider.
+     * @return The raw rSTS response.
+     * @throws SafeguardForJavaException If the rSTS cannot be reached.
+     */
+    protected RstsResponse requestDeviceCode(String clientId, String scope) throws SafeguardForJavaException {
+        final String body = new StringBuilder("{")
+                .append(Utils.toJsonString("client_id", clientId, false))
+                .append(Utils.toJsonString("scope", scope, true))
+                .append("}").toString();
+
+        CloseableHttpResponse response = rstsClient.execPOST(DEVICE_LOGIN_PATH, null, null, null, jsonBody(body));
+        if (response == null) {
+            throw new SafeguardForJavaException(
+                    String.format("Unable to connect to RSTS service %s", rstsClient.getBaseURL()));
+        }
+        return new RstsResponse(response.getCode(), Utils.getResponse(response));
+    }
+
+    /**
+     * Polls the rSTS token endpoint with the device code. Exposed for testability.
+     *
+     * @param clientId OAuth client id (may be empty).
+     * @param deviceCode The device code returned from the device authorization request.
+     * @return The raw rSTS response.
+     * @throws SafeguardForJavaException If the rSTS cannot be reached.
+     */
+    protected RstsResponse requestToken(String clientId, String deviceCode) throws SafeguardForJavaException {
+        final String body = new StringBuilder("{")
+                .append(Utils.toJsonString("grant_type", DEVICE_CODE_GRANT_TYPE, false))
+                .append(Utils.toJsonString("device_code", jsonEscape(deviceCode), true))
+                .append(Utils.toJsonString("client_id", clientId, true))
+                .append("}").toString();
+
+        CloseableHttpResponse response = rstsClient.execPOST(TOKEN_PATH, null, null, null, jsonBody(body));
+        if (response == null) {
+            throw new SafeguardForJavaException(
+                    String.format("Unable to connect to RSTS service %s", rstsClient.getBaseURL()));
+        }
+        return new RstsResponse(response.getCode(), Utils.getResponse(response));
+    }
+
+    /**
+     * Waits before the next poll attempt. Sleeps in one-second increments so the
+     * cancel hook can abort promptly during a wait. Exposed for testability.
+     *
+     * @param seconds The number of seconds to wait.
+     */
+    protected void waitInterval(int seconds) {
+        for (int i = 0; i < seconds; i++) {
+            if (isCancelled()) {
+                return;
+            }
+            sleepMillis(1000L);
+        }
+    }
+
+    /**
+     * Sleeps for the given number of milliseconds. Exposed for testability.
+     *
+     * @param millis The number of milliseconds to sleep.
+     */
+    protected void sleepMillis(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    /**
+     * Returns a monotonic time source in milliseconds used to enforce the
+     * {@code expires_in} deadline. Exposed for testability.
+     *
+     * @return A monotonic timestamp in milliseconds.
+     */
+    protected long monotonicMillis() {
+        return System.nanoTime() / 1_000_000L;
+    }
+
+    int getCurrentPollingIntervalSeconds() {
+        return currentPollingIntervalSeconds;
+    }
+
+    private static JsonObject jsonBody(final String json) {
+        return () -> json;
+    }
+
+    private static String jsonEscape(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+
+    private JsonNode parseJson(String body) throws SafeguardForJavaException {
+        try {
+            JsonNode node = new ObjectMapper().readTree(body == null ? "" : body);
+            if (node == null || node.isNull()) {
+                throw new SafeguardForJavaException("Empty or invalid JSON response from RSTS");
+            }
+            return node;
+        } catch (SafeguardForJavaException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new SafeguardForJavaException("Unable to parse JSON response from RSTS", ex);
+        }
+    }
+
+    private static String extractError(String body) {
+        try {
+            JsonNode node = new ObjectMapper().readTree(body == null ? "" : body);
+            if (node != null && node.has("error")) {
+                return node.get("error").asText();
+            }
+        } catch (java.io.IOException ex) {
+            // Fall through; an unparseable body yields no error code.
+        }
+        return "";
+    }
+
+    private static String requireString(JsonNode node, String field) throws SafeguardForJavaException {
+        JsonNode value = node.get(field);
+        if (value == null || value.isNull() || Utils.isNullOrEmpty(value.asText())) {
+            throw new SafeguardForJavaException(
+                    String.format("Device authorization response is missing required field '%s'", field));
+        }
+        return value.asText();
+    }
+
+    private static int requireInt(JsonNode node, String field) throws SafeguardForJavaException {
+        JsonNode value = node.get(field);
+        if (value == null || value.isNull() || !value.canConvertToInt()) {
+            throw new SafeguardForJavaException(
+                    String.format("Device authorization response is missing required field '%s'", field));
+        }
+        return value.asInt();
+    }
+
+    private static String optionalString(JsonNode node, String field) {
+        JsonNode value = node.get(field);
+        if (value == null || value.isNull() || Utils.isNullOrEmpty(value.asText())) {
+            return null;
+        }
+        return value.asText();
+    }
+
+    private static Integer optionalInt(JsonNode node, String field) {
+        JsonNode value = node.get(field);
+        if (value == null || value.isNull() || !value.canConvertToInt()) {
+            return null;
+        }
+        return value.asInt();
+    }
+
+    @Override
+    public Object cloneObject() throws SafeguardForJavaException {
+        try {
+            DeviceCodeAuthenticator auth = new DeviceCodeAuthenticator(getNetworkAddress(), displayCallback,
+                    parameters, getApiVersion(), isIgnoreSsl(), getValidationCallback());
+            auth.accessToken = this.accessToken == null ? null : this.accessToken.clone();
+            return auth;
+        } catch (ArgumentException ex) {
+            logger.error("Exception occurred", ex);
+        }
+        return null;
+    }
+
+    @Override
+    public void dispose() {
+        super.dispose();
+        disposed = true;
+    }
+
+    @Override
+    protected void finalize() throws Throwable {
+        try {
+            disposed = true;
+        } finally {
+            super.finalize();
+        }
+    }
+
+    /**
+     * Minimal holder for an rSTS HTTP response (status code and body). Used to
+     * decouple the Device Code protocol logic from the HTTP transport so the
+     * authenticator can be unit tested without live network calls.
+     */
+    protected static final class RstsResponse {
+
+        private final int statusCode;
+        private final String body;
+
+        /**
+         * Creates a response holder.
+         *
+         * @param statusCode HTTP status code.
+         * @param body Response body.
+         */
+        public RstsResponse(int statusCode, String body) {
+            this.statusCode = statusCode;
+            this.body = body;
+        }
+
+        /**
+         * Gets the HTTP status code.
+         *
+         * @return The status code.
+         */
+        public int getStatusCode() {
+            return statusCode;
+        }
+
+        /**
+         * Gets the response body.
+         *
+         * @return The response body.
+         */
+        public String getBody() {
+            return body;
+        }
+    }
+}

--- a/src/main/java/com/oneidentity/safeguard/safeguardjava/authentication/DeviceCodeLoginParameters.java
+++ b/src/main/java/com/oneidentity/safeguard/safeguardjava/authentication/DeviceCodeLoginParameters.java
@@ -1,0 +1,116 @@
+package com.oneidentity.safeguard.safeguardjava.authentication;
+
+import com.oneidentity.safeguard.safeguardjava.exceptions.ArgumentException;
+import java.util.function.Supplier;
+
+/**
+ * Tunable parameters for the Device Code (OAuth 2.0 Device Authorization Grant,
+ * RFC 8628) login flow.
+ * <p>
+ * All parameters are optional and have sensible defaults that match the
+ * SafeguardDotNet implementation:
+ * <ul>
+ *   <li>{@code scope} selects the authentication provider; defaults to the
+ *       local provider.</li>
+ *   <li>{@code clientId} defaults to empty, which the rSTS normalizes to its
+ *       built-in application client id.</li>
+ *   <li>{@code pollingIntervalSeconds} defaults to 5 and is automatically
+ *       increased by 5 seconds when the appliance returns {@code slow_down}.</li>
+ *   <li>{@code isCancelled} is a caller-driven cancel hook (the idiomatic Java
+ *       stand-in for .NET's {@code CancellationToken}); by default the flow is
+ *       never cancelled.</li>
+ * </ul>
+ * The poll deadline is always the appliance's {@code expires_in} value and is
+ * not configurable here.
+ */
+public class DeviceCodeLoginParameters {
+
+    /** Default scope, selecting the built-in local authentication provider. */
+    public static final String DEFAULT_SCOPE = "rsts:sts:primaryproviderid:local";
+
+    /** Default polling interval in seconds. */
+    public static final int DEFAULT_POLLING_INTERVAL_SECONDS = 5;
+
+    private String scope = DEFAULT_SCOPE;
+    private String clientId = "";
+    private int pollingIntervalSeconds = DEFAULT_POLLING_INTERVAL_SECONDS;
+    private Supplier<Boolean> isCancelled = () -> Boolean.FALSE;
+
+    /**
+     * Gets the scope used to select the authentication provider.
+     *
+     * @return The scope value.
+     */
+    public String getScope() {
+        return scope;
+    }
+
+    /**
+     * Sets the scope used to select the authentication provider. A null or empty
+     * value resets the scope to {@link #DEFAULT_SCOPE}.
+     *
+     * @param scope The scope value.
+     */
+    public void setScope(String scope) {
+        this.scope = (scope == null || scope.trim().isEmpty()) ? DEFAULT_SCOPE : scope;
+    }
+
+    /**
+     * Gets the OAuth client id. An empty value lets the rSTS use its built-in
+     * application client id.
+     *
+     * @return The client id.
+     */
+    public String getClientId() {
+        return clientId;
+    }
+
+    /**
+     * Sets the OAuth client id. A null value is treated as empty.
+     *
+     * @param clientId The client id.
+     */
+    public void setClientId(String clientId) {
+        this.clientId = clientId == null ? "" : clientId;
+    }
+
+    /**
+     * Gets the polling interval in seconds.
+     *
+     * @return The polling interval in seconds.
+     */
+    public int getPollingIntervalSeconds() {
+        return pollingIntervalSeconds;
+    }
+
+    /**
+     * Sets the polling interval in seconds.
+     *
+     * @param pollingIntervalSeconds The polling interval; must be greater than zero.
+     * @throws ArgumentException If the value is less than or equal to zero.
+     */
+    public void setPollingIntervalSeconds(int pollingIntervalSeconds) throws ArgumentException {
+        if (pollingIntervalSeconds <= 0) {
+            throw new ArgumentException("The pollingIntervalSeconds parameter must be greater than zero");
+        }
+        this.pollingIntervalSeconds = pollingIntervalSeconds;
+    }
+
+    /**
+     * Gets the caller-driven cancel hook.
+     *
+     * @return A supplier that returns {@code true} when the flow should be cancelled.
+     */
+    public Supplier<Boolean> getIsCancelled() {
+        return isCancelled;
+    }
+
+    /**
+     * Sets the caller-driven cancel hook. A null value disables cancellation.
+     *
+     * @param isCancelled A supplier that returns {@code true} when the flow should be cancelled.
+     */
+    public void setIsCancelled(Supplier<Boolean> isCancelled) {
+        this.isCancelled = isCancelled == null ? () -> Boolean.FALSE : isCancelled;
+    }
+}

--- a/src/main/java/com/oneidentity/safeguard/safeguardjava/data/DeviceCodeInfo.java
+++ b/src/main/java/com/oneidentity/safeguard/safeguardjava/data/DeviceCodeInfo.java
@@ -1,0 +1,86 @@
+package com.oneidentity.safeguard.safeguardjava.data;
+
+/**
+ * Carries the OAuth 2.0 Device Authorization Grant (RFC 8628) values that are
+ * intended to be shown to the user so that they can complete authentication in
+ * a browser on any device.
+ * <p>
+ * This object is passed to a caller-provided
+ * {@link com.oneidentity.safeguard.safeguardjava.IDeviceCodeDisplayCallback}.
+ * The raw {@code device_code} that the library uses internally to poll for the
+ * token is deliberately <b>not</b> exposed here.
+ */
+public class DeviceCodeInfo {
+
+    private final String userCode;
+    private final String verificationUri;
+    private final String verificationUriComplete;
+    private final int expiresIn;
+    private final Integer interval;
+
+    /**
+     * Creates a new device code info object.
+     *
+     * @param userCode The user code the end user must enter (RFC 8628 {@code user_code}).
+     * @param verificationUri The verification URI the end user should visit ({@code verification_uri}).
+     * @param verificationUriComplete The verification URI with the user code embedded
+     *        ({@code verification_uri_complete}); may be {@code null} if not supplied.
+     * @param expiresIn The number of seconds until the device code expires ({@code expires_in}).
+     * @param interval The minimum polling interval in seconds suggested by the appliance
+     *        ({@code interval}); may be {@code null} if not supplied.
+     */
+    public DeviceCodeInfo(String userCode, String verificationUri, String verificationUriComplete,
+            int expiresIn, Integer interval) {
+        this.userCode = userCode;
+        this.verificationUri = verificationUri;
+        this.verificationUriComplete = verificationUriComplete;
+        this.expiresIn = expiresIn;
+        this.interval = interval;
+    }
+
+    /**
+     * Gets the user code the end user must enter to authorize the device.
+     *
+     * @return The user code.
+     */
+    public String getUserCode() {
+        return userCode;
+    }
+
+    /**
+     * Gets the verification URI the end user should visit in a browser.
+     *
+     * @return The verification URI.
+     */
+    public String getVerificationUri() {
+        return verificationUri;
+    }
+
+    /**
+     * Gets the verification URI with the user code already embedded, when the
+     * appliance provides it. Prefer displaying this value when present.
+     *
+     * @return The complete verification URI, or {@code null} if not supplied.
+     */
+    public String getVerificationUriComplete() {
+        return verificationUriComplete;
+    }
+
+    /**
+     * Gets the number of seconds until the device code expires.
+     *
+     * @return The lifetime of the device code in seconds.
+     */
+    public int getExpiresIn() {
+        return expiresIn;
+    }
+
+    /**
+     * Gets the minimum polling interval suggested by the appliance, in seconds.
+     *
+     * @return The suggested interval, or {@code null} if not supplied.
+     */
+    public Integer getInterval() {
+        return interval;
+    }
+}

--- a/src/test/java/com/oneidentity/safeguard/safeguardjava/authentication/DeviceCodeAuthenticatorTest.java
+++ b/src/test/java/com/oneidentity/safeguard/safeguardjava/authentication/DeviceCodeAuthenticatorTest.java
@@ -1,0 +1,410 @@
+package com.oneidentity.safeguard.safeguardjava.authentication;
+
+import com.oneidentity.safeguard.safeguardjava.IDeviceCodeDisplayCallback;
+import com.oneidentity.safeguard.safeguardjava.Safeguard;
+import com.oneidentity.safeguard.safeguardjava.data.DeviceCodeInfo;
+import com.oneidentity.safeguard.safeguardjava.data.JsonObject;
+import com.oneidentity.safeguard.safeguardjava.exceptions.ArgumentException;
+import com.oneidentity.safeguard.safeguardjava.exceptions.SafeguardForJavaException;
+import com.oneidentity.safeguard.safeguardjava.restclient.RestClient;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.net.ssl.HostnameVerifier;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.http.message.BasicClassicHttpResponse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import org.junit.Test;
+
+/**
+ * Unit tests for the Device Code (OAuth 2.0 Device Authorization Grant, RFC 8628)
+ * authenticator. The rSTS HTTP transport and the sleeper/clock are overridden via
+ * protected seams so the protocol logic can be verified without a live appliance.
+ */
+public class DeviceCodeAuthenticatorTest {
+
+    private static final String DEVICE_LOGIN_JSON =
+            "{\"device_code\":\"DEV-CODE-SECRET\",\"user_code\":\"WXYZ-1234\","
+            + "\"verification_uri\":\"https://appliance/RSTS/UserLogin\","
+            + "\"verification_uri_complete\":\"https://appliance/RSTS/UserLogin?user_code=WXYZ-1234\","
+            + "\"expires_in\":300,\"interval\":5}";
+
+    private static DeviceCodeLoginParameters defaultParams() {
+        return new DeviceCodeLoginParameters();
+    }
+
+    private static IDeviceCodeDisplayCallback noopCallback() {
+        return info -> { };
+    }
+
+    // ----- Disabled-grant detection -----
+
+    @Test
+    public void disabledGrantHtmlIsDetectedWithoutJsonParsing() {
+        String html = "<html><body>OAuth2 Device Code grant type is not allowed.</body></html>";
+        TestAuthenticator auth = newAuth(noopCallback(), defaultParams());
+        auth.deviceResponse = response(400, html);
+
+        try {
+            auth.invokeGetRstsToken();
+            fail("Expected a disabled-grant exception");
+        } catch (SafeguardForJavaException ex) {
+            String msg = ex.getMessage();
+            assertTrue("Message should instruct to enable Device Code: " + msg,
+                    msg.contains("Device Code grant type is not enabled"));
+            assertTrue("Message should reference the grant types setting: " + msg,
+                    msg.contains("Allowed OAuth2 Grant Types"));
+            // The HTML error path must not have produced a JSON parse error.
+            assertTrue("Should not surface a JSON parse error: " + msg,
+                    !msg.toLowerCase().contains("parse json"));
+        }
+        assertEquals("Disabled grant must short-circuit before any token poll", 0, auth.requestTokenCalls);
+    }
+
+    @Test
+    public void nonDisabledErrorFromDeviceLoginThrowsGenericError() {
+        TestAuthenticator auth = newAuth(noopCallback(), defaultParams());
+        auth.deviceResponse = response(503, "Service Unavailable");
+
+        try {
+            auth.invokeGetRstsToken();
+            fail("Expected a generic error");
+        } catch (SafeguardForJavaException ex) {
+            assertTrue(ex.getMessage().contains("Error requesting device code"));
+        }
+    }
+
+    // ----- Display callback -----
+
+    @Test
+    public void displayCallbackReceivesDisplayValuesOnly() throws Exception {
+        final List<DeviceCodeInfo> captured = new ArrayList<>();
+        TestAuthenticator auth = newAuth(captured::add, defaultParams());
+        auth.deviceResponse = response(200, DEVICE_LOGIN_JSON);
+        auth.tokenResponses.add(response(200, "{\"access_token\":\"RSTS-TOKEN\"}"));
+
+        auth.invokeGetRstsToken();
+
+        assertEquals(1, captured.size());
+        DeviceCodeInfo info = captured.get(0);
+        assertEquals("WXYZ-1234", info.getUserCode());
+        assertEquals("https://appliance/RSTS/UserLogin", info.getVerificationUri());
+        assertEquals("https://appliance/RSTS/UserLogin?user_code=WXYZ-1234", info.getVerificationUriComplete());
+        assertEquals(300, info.getExpiresIn());
+        assertEquals(Integer.valueOf(5), info.getInterval());
+        // DeviceCodeInfo deliberately exposes no device_code accessor (compile-time guarantee).
+    }
+
+    @Test
+    public void optionalDeviceLoginFieldsMayBeAbsent() throws Exception {
+        final List<DeviceCodeInfo> captured = new ArrayList<>();
+        TestAuthenticator auth = newAuth(captured::add, defaultParams());
+        auth.deviceResponse = response(200, "{\"device_code\":\"D\",\"user_code\":\"U\","
+                + "\"verification_uri\":\"https://v\",\"expires_in\":120}");
+        auth.tokenResponses.add(response(200, "{\"access_token\":\"RSTS-TOKEN\"}"));
+
+        auth.invokeGetRstsToken();
+
+        DeviceCodeInfo info = captured.get(0);
+        assertNull(info.getVerificationUriComplete());
+        assertNull(info.getInterval());
+        assertEquals(120, info.getExpiresIn());
+    }
+
+    @Test
+    public void missingRequiredDeviceLoginFieldThrows() {
+        TestAuthenticator auth = newAuth(noopCallback(), defaultParams());
+        auth.deviceResponse = response(200, "{\"user_code\":\"U\",\"verification_uri\":\"https://v\",\"expires_in\":120}");
+
+        try {
+            auth.invokeGetRstsToken();
+            fail("Expected missing device_code error");
+        } catch (SafeguardForJavaException ex) {
+            assertTrue(ex.getMessage().contains("device_code"));
+        }
+    }
+
+    // ----- Poll-loop transitions -----
+
+    @Test
+    public void authorizationPendingThenSuccessReturnsAccessToken() throws Exception {
+        TestAuthenticator auth = newAuth(noopCallback(), defaultParams());
+        auth.deviceResponse = response(200, DEVICE_LOGIN_JSON);
+        auth.tokenResponses.add(response(400, "{\"error\":\"authorization_pending\"}"));
+        auth.tokenResponses.add(response(400, "{\"error\":\"authorization_pending\"}"));
+        auth.tokenResponses.add(response(200, "{\"access_token\":\"RSTS-FINAL\"}"));
+
+        char[] token = auth.invokeGetRstsToken();
+
+        assertEquals("RSTS-FINAL", new String(token));
+        assertEquals(3, auth.requestTokenCalls);
+    }
+
+    @Test
+    public void slowDownIncreasesPollingIntervalByFiveSeconds() throws Exception {
+        TestAuthenticator auth = newAuth(noopCallback(), defaultParams());
+        auth.deviceResponse = response(200, DEVICE_LOGIN_JSON);
+        auth.tokenResponses.add(response(400, "{\"error\":\"slow_down\"}"));
+        auth.tokenResponses.add(response(200, "{\"access_token\":\"RSTS-FINAL\"}"));
+
+        char[] token = auth.invokeGetRstsToken();
+
+        assertEquals("RSTS-FINAL", new String(token));
+        // Default polling interval is 5; after one slow_down it must be 10.
+        assertEquals(10, auth.getCurrentPollingIntervalSeconds());
+    }
+
+    // ----- Terminal failures -----
+
+    @Test
+    public void accessDeniedThrows() {
+        TestAuthenticator auth = newAuth(noopCallback(), defaultParams());
+        auth.deviceResponse = response(200, DEVICE_LOGIN_JSON);
+        auth.tokenResponses.add(response(400, "{\"error\":\"access_denied\"}"));
+
+        try {
+            auth.invokeGetRstsToken();
+            fail("Expected access_denied error");
+        } catch (SafeguardForJavaException ex) {
+            assertTrue(ex.getMessage().toLowerCase().contains("denied"));
+        }
+    }
+
+    @Test
+    public void expiredTokenThrows() {
+        TestAuthenticator auth = newAuth(noopCallback(), defaultParams());
+        auth.deviceResponse = response(200, DEVICE_LOGIN_JSON);
+        auth.tokenResponses.add(response(400, "{\"error\":\"expired_token\"}"));
+
+        try {
+            auth.invokeGetRstsToken();
+            fail("Expected expired_token error");
+        } catch (SafeguardForJavaException ex) {
+            assertTrue(ex.getMessage().toLowerCase().contains("expired"));
+        }
+    }
+
+    @Test
+    public void deadlineExceededAtExpiresInCutoffThrows() {
+        TestAuthenticator auth = newAuth(noopCallback(), defaultParams());
+        auth.deviceResponse = response(200, DEVICE_LOGIN_JSON);
+        // First clock read computes the deadline (0 + 300s); the next read jumps past it.
+        auth.clockValues.add(0L);
+        auth.clockValues.add(300_000L + 1L);
+
+        try {
+            auth.invokeGetRstsToken();
+            fail("Expected a timeout/deadline error");
+        } catch (SafeguardForJavaException ex) {
+            assertTrue(ex.getMessage().toLowerCase().contains("timed out"));
+        }
+        assertEquals("Deadline must be enforced before polling", 0, auth.requestTokenCalls);
+    }
+
+    // ----- Cancel hook -----
+
+    @Test
+    public void cancelHookAbortsBeforePolling() {
+        DeviceCodeLoginParameters params = new DeviceCodeLoginParameters();
+        params.setIsCancelled(() -> Boolean.TRUE);
+        TestAuthenticator auth = newAuth(noopCallback(), params);
+        auth.deviceResponse = response(200, DEVICE_LOGIN_JSON);
+
+        try {
+            auth.invokeGetRstsToken();
+            fail("Expected cancellation");
+        } catch (SafeguardForJavaException ex) {
+            assertTrue(ex.getMessage().toLowerCase().contains("cancel"));
+        }
+        assertEquals(0, auth.requestTokenCalls);
+    }
+
+    @Test
+    public void cancelHookAbortsDuringWaitPeriod() {
+        DeviceCodeLoginParameters params = new DeviceCodeLoginParameters();
+        params.setIsCancelled(() -> Boolean.TRUE);
+        TestAuthenticator auth = newAuth(noopCallback(), params);
+
+        // Production waitInterval must honor the cancel hook and not sleep at all.
+        auth.waitInterval(10);
+        assertEquals("Cancelled wait must not sleep", 0, auth.sleepCalls.get());
+    }
+
+    // ----- rSTS -> Safeguard UserToken exchange through AuthenticatorBase -----
+
+    @Test
+    public void refreshAccessTokenExchangesRstsTokenForUserToken() throws Exception {
+        TestAuthenticator auth = newAuth(noopCallback(), defaultParams());
+        auth.deviceResponse = response(200, DEVICE_LOGIN_JSON);
+        auth.tokenResponses.add(response(200, "{\"access_token\":\"RSTS-EXCHANGE-ME\"}"));
+
+        CapturingRestClient fakeCore = new CapturingRestClient("https://localhost/service/core/v4");
+        fakeCore.responseToReturn = httpResponse(200, "{\"UserToken\":\"USER-TOKEN-42\"}");
+        auth.coreClient = fakeCore;
+
+        auth.refreshAccessToken();
+
+        assertNotNull(auth.getAccessToken());
+        assertEquals("USER-TOKEN-42", new String(auth.getAccessToken()));
+        // Prove the authenticator only supplied the rSTS token to the base-class exchange.
+        assertNotNull(fakeCore.lastPath);
+        assertEquals("Token/LoginResponse", fakeCore.lastPath);
+        assertTrue("Exchange body must carry the rSTS token: " + fakeCore.lastBody,
+                fakeCore.lastBody.contains("RSTS-EXCHANGE-ME"));
+    }
+
+    // ----- Parameter validation and factory wiring -----
+
+    @Test
+    public void getIdIsDeviceCode() {
+        TestAuthenticator auth = newAuth(noopCallback(), defaultParams());
+        assertEquals("DeviceCode", auth.getId());
+    }
+
+    @Test
+    public void parametersRejectNonPositivePollingInterval() {
+        try {
+            new DeviceCodeLoginParameters().setPollingIntervalSeconds(0);
+            fail("Expected ArgumentException for non-positive interval");
+        } catch (ArgumentException ex) {
+            assertTrue(ex.getMessage().contains("greater than zero"));
+        }
+    }
+
+    @Test
+    public void parametersHaveExpectedDefaults() {
+        DeviceCodeLoginParameters p = new DeviceCodeLoginParameters();
+        assertEquals("rsts:sts:primaryproviderid:local", p.getScope());
+        assertEquals("", p.getClientId());
+        assertEquals(5, p.getPollingIntervalSeconds());
+        assertEquals(Boolean.FALSE, p.getIsCancelled().get());
+    }
+
+    @Test
+    public void constructorRejectsNullDisplayCallback() {
+        try {
+            new DeviceCodeAuthenticator("localhost", null, defaultParams(), 4, true, null);
+            fail("Expected ArgumentException for null display callback");
+        } catch (ArgumentException ex) {
+            assertTrue(ex.getMessage().contains("displayCallback"));
+        }
+    }
+
+    @Test
+    public void connectDeviceCodeFactoryRejectsNullDisplayCallback() throws Exception {
+        try {
+            Safeguard.connectDeviceCode("localhost", null, null, (Integer) null, true);
+            fail("Expected ArgumentException for null display callback");
+        } catch (ArgumentException ex) {
+            assertTrue(ex.getMessage().contains("displayCallback"));
+        }
+    }
+
+    // ----- Test fixtures -----
+
+    private static TestAuthenticator newAuth(IDeviceCodeDisplayCallback cb, DeviceCodeLoginParameters params) {
+        try {
+            return new TestAuthenticator("localhost", cb, params, 4, true, null);
+        } catch (ArgumentException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    private static DeviceCodeAuthenticator.RstsResponse response(int code, String body) {
+        return new DeviceCodeAuthenticator.RstsResponse(code, body);
+    }
+
+    private static CloseableHttpResponse httpResponse(int code, String body) {
+        BasicClassicHttpResponse r = new BasicClassicHttpResponse(code);
+        r.setEntity(new StringEntity(body, ContentType.APPLICATION_JSON));
+        return CloseableHttpResponse.adapt(r);
+    }
+
+    /**
+     * Test double that scripts the rSTS responses and neutralizes the sleeper/clock.
+     */
+    private static final class TestAuthenticator extends DeviceCodeAuthenticator {
+
+        RstsResponse deviceResponse;
+        final Deque<RstsResponse> tokenResponses = new ArrayDeque<>();
+        final Deque<Long> clockValues = new ArrayDeque<>();
+        final AtomicInteger sleepCalls = new AtomicInteger(0);
+        int requestTokenCalls;
+
+        TestAuthenticator(String networkAddress, IDeviceCodeDisplayCallback displayCallback,
+                DeviceCodeLoginParameters parameters, int apiVersion, boolean ignoreSsl,
+                HostnameVerifier validationCallback) throws ArgumentException {
+            super(networkAddress, displayCallback, parameters, apiVersion, ignoreSsl, validationCallback);
+        }
+
+        char[] invokeGetRstsToken() throws SafeguardForJavaException {
+            try {
+                return getRstsTokenInternal();
+            } catch (com.oneidentity.safeguard.safeguardjava.exceptions.ObjectDisposedException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+
+        @Override
+        protected RstsResponse requestDeviceCode(String clientId, String scope) {
+            return deviceResponse;
+        }
+
+        @Override
+        protected RstsResponse requestToken(String clientId, String deviceCode) {
+            requestTokenCalls++;
+            RstsResponse next = tokenResponses.poll();
+            if (next == null) {
+                throw new IllegalStateException("No scripted token response available");
+            }
+            return next;
+        }
+
+        @Override
+        protected void sleepMillis(long millis) {
+            sleepCalls.incrementAndGet();
+        }
+
+        @Override
+        protected long monotonicMillis() {
+            Long v = clockValues.poll();
+            return v == null ? 0L : v;
+        }
+    }
+
+    /**
+     * Fake {@link RestClient} that records the posted exchange request and returns a
+     * canned {@code Token/LoginResponse}.
+     */
+    private static final class CapturingRestClient extends RestClient {
+
+        CloseableHttpResponse responseToReturn;
+        String lastPath;
+        String lastBody;
+
+        CapturingRestClient(String baseUrl) {
+            super(baseUrl, true, null);
+        }
+
+        @Override
+        public CloseableHttpResponse execPOST(String path, Map<String, String> queryParams,
+                Map<String, String> headers, Integer timeout, JsonObject requestEntity) {
+            this.lastPath = path;
+            try {
+                this.lastBody = requestEntity == null ? null : requestEntity.toJson();
+            } catch (SafeguardForJavaException ex) {
+                throw new RuntimeException(ex);
+            }
+            return responseToReturn;
+        }
+    }
+}

--- a/tests/safeguardjavaclient/pom.xml
+++ b/tests/safeguardjavaclient/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.oneidentity.safeguard</groupId>
             <artifactId>safeguardjava</artifactId>
-            <version>8.2.2</version>
+            <version>8.3.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/tests/safeguardjavaclient/src/main/java/com/oneidentity/safeguard/safeguardclient/SafeguardJavaClient.java
+++ b/tests/safeguardjavaclient/src/main/java/com/oneidentity/safeguard/safeguardclient/SafeguardJavaClient.java
@@ -6,10 +6,13 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.oneidentity.safeguard.safeguardjava.ISafeguardA2AContext;
 import com.oneidentity.safeguard.safeguardjava.IA2ARetrievableAccount;
+import com.oneidentity.safeguard.safeguardjava.IDeviceCodeDisplayCallback;
 import com.oneidentity.safeguard.safeguardjava.ISafeguardConnection;
 import com.oneidentity.safeguard.safeguardjava.ISafeguardSessionsConnection;
 import com.oneidentity.safeguard.safeguardjava.Safeguard;
 import com.oneidentity.safeguard.safeguardjava.SafeguardForPrivilegedSessions;
+import com.oneidentity.safeguard.safeguardjava.authentication.DeviceCodeLoginParameters;
+import com.oneidentity.safeguard.safeguardjava.data.DeviceCodeInfo;
 import com.oneidentity.safeguard.safeguardjava.data.FullResponse;
 import com.oneidentity.safeguard.safeguardjava.data.Method;
 import com.oneidentity.safeguard.safeguardjava.data.Service;
@@ -26,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Scanner;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class SafeguardJavaClient {
 
@@ -69,6 +73,12 @@ public class SafeguardJavaClient {
 
             if (opts.retrievableAccounts || opts.retrievePassword || opts.setPassword) {
                 handleA2aOperation(opts);
+                System.exit(0);
+                return;
+            }
+
+            if (opts.deviceCode) {
+                handleDeviceCode(opts);
                 System.exit(0);
                 return;
             }
@@ -261,6 +271,55 @@ public class SafeguardJavaClient {
         } else {
             String result = spsConnection.invokeMethod(method, opts.relativeUrl, opts.body);
             System.out.println(result);
+        }
+    }
+
+    private static void handleDeviceCode(ToolOptions opts) throws Exception {
+        final AtomicReference<DeviceCodeInfo> captured = new AtomicReference<>();
+
+        DeviceCodeLoginParameters params = new DeviceCodeLoginParameters();
+        if (opts.identityProvider != null && !opts.identityProvider.trim().isEmpty()) {
+            params.setScope("rsts:sts:primaryproviderid:" + opts.identityProvider);
+        }
+        // Without a human to approve, cancel as soon as the verification values are received.
+        params.setIsCancelled(() -> captured.get() != null);
+
+        IDeviceCodeDisplayCallback displayCallback = info -> {
+            captured.set(info);
+            System.err.println("To sign in, visit "
+                    + (info.getVerificationUriComplete() != null
+                            ? info.getVerificationUriComplete() : info.getVerificationUri())
+                    + " and enter code " + info.getUserCode());
+        };
+
+        System.err.println("Connecting to " + opts.appliance + " via Device Code flow");
+        try {
+            ISafeguardConnection connection = Safeguard.connectDeviceCode(
+                    opts.appliance, displayCallback, params, (Integer) null, opts.insecure);
+            // A human approved within the deadline.
+            String me = connection.invokeMethod(Service.Core, Method.Get, "Me", null, null, null, null);
+            ObjectNode json = mapper.createObjectNode();
+            json.put("Approved", true);
+            json.set("Me", mapper.readTree(me));
+            System.out.println(mapper.writeValueAsString(json));
+            connection.dispose();
+        } catch (Exception ex) {
+            DeviceCodeInfo info = captured.get();
+            if (info != null) {
+                // Expected no-human path: report the display values that were received.
+                ObjectNode json = mapper.createObjectNode();
+                ObjectNode display = json.putObject("DeviceCodeDisplay");
+                display.put("UserCode", info.getUserCode());
+                display.put("VerificationUri", info.getVerificationUri());
+                if (info.getVerificationUriComplete() != null) {
+                    display.put("VerificationUriComplete", info.getVerificationUriComplete());
+                }
+                display.put("ExpiresIn", info.getExpiresIn());
+                System.out.println(mapper.writeValueAsString(json));
+                return;
+            }
+            // No display values means the request failed (e.g. grant disabled); surface the error.
+            throw ex;
         }
     }
 

--- a/tests/safeguardjavaclient/src/main/java/com/oneidentity/safeguard/safeguardclient/ToolOptions.java
+++ b/tests/safeguardjavaclient/src/main/java/com/oneidentity/safeguard/safeguardclient/ToolOptions.java
@@ -91,6 +91,10 @@ public class ToolOptions {
         description = "Use PKCE (Proof Key for Code Exchange) authentication instead of password grant")
     boolean pkce;
 
+    @Option(names = {"--device-code"}, defaultValue = "false",
+        description = "Use the OAuth 2.0 Device Code flow; displays the verification URL/code as JSON and exits")
+    boolean deviceCode;
+
     @Option(names = {"-R", "--resource-owner"}, arity = "1",
         description = "Enable (true) or disable (false) the resource owner password grant type and exit")
     Boolean resourceOwner;


### PR DESCRIPTION
Adds OAuth 2.0 Device Authorization Grant (RFC 8628) login support.

**What''s included**
- `DeviceCodeInfo`, `DeviceCodeLoginParameters`, and a required caller-supplied display callback (`IDeviceCodeDisplayCallback`) — the library performs no console I/O and never launches a browser; the caller owns presentation of the verification URL and user code.
- `connectDeviceCode` overloads and Device Code event-listener factories.
- `--device-code` option in the sample client; README docs and a usage sample.

**Tests**
- 18 new device-code unit tests; full suite green (`mvn clean verify`, 22 unit tests).
- Live integration suite (Device Code Auth) green against a test appliance.

Version bumped to 8.3.0-SNAPSHOT (new functionality → minor).