### PR TITLE
Bump dev revision to 8.3.1-SNAPSHOT after 8.3.0 GA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <revision>8.3.0-SNAPSHOT</revision>
+        <revision>8.3.1-SNAPSHOT</revision>
         <gpgkeyname>keyname</gpgkeyname>
     </properties>
 


### PR DESCRIPTION
Bumps the checked-in development version (the evision property in the root pom.xml) from 8.3.0-SNAPSHOT to 8.3.1-SNAPSHOT.

**Why:** 8.3.0 has shipped as a GA release (tag 8.3.0, published to Maven Central), but the repository's evision was still 8.3.0-SNAPSHOT, so local/SNAPSHOT dev builds were re-cutting the already-released version. Advancing to 8.3.1-SNAPSHOT moves the dev line ahead to the next planned patch release. Release builds continue to derive their version from the git tag via -Drevision, so this only affects non-tag/SNAPSHOT builds.

No functional code changes.

---
🤖 *This description was generated on behalf of Dan Peterson by GitHub Copilot CLI (Claude Opus 4.8/Anthropic).*